### PR TITLE
Fix HD mode on Prime 1

### DIFF
--- a/cmake/src/main/hook/patch/CMakeLists.txt
+++ b/cmake/src/main/hook/patch/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCE_FILES
         ${SRC}/redir.c
         ${SRC}/sigsegv.c
         ${SRC}/sound.c
+        ${SRC}/sysinfo.c
         ${SRC}/usb-emu.c
         ${SRC}/usb-init-fix.c
         ${SRC}/usb-mnt.c

--- a/src/main/hook/patch/sysinfo.c
+++ b/src/main/hook/patch/sysinfo.c
@@ -1,0 +1,31 @@
+#define LOG_MODULE "patch-sysinfo"
+
+#include <sys/sysinfo.h>
+#include <stdbool.h>
+
+#include "capnhook/hook/lib.h"
+
+#include "util/log.h"
+
+typedef int (*sysinfo_t)(struct sysinfo *info);
+
+static bool patch_sysinfo_initialized;
+static sysinfo_t patch_sysinfo_real_sysinfo;
+int sysinfo(struct sysinfo *info) {
+    if (!patch_sysinfo_real_sysinfo) {
+        patch_sysinfo_real_sysinfo = (sysinfo_t)cnh_lib_get_func_addr("sysinfo");
+    }
+
+    // Prime will not run in HD if totalram / (mem_unit * 1024) is less than 999999
+    int ret = patch_sysinfo_real_sysinfo(info);
+    info->totalram = info->totalram * info->mem_unit;
+    info->mem_unit = 1;
+
+    return ret;
+}
+
+void patch_sysinfo_init()
+{
+  patch_sysinfo_initialized = true;
+  log_info("Initialized");
+}

--- a/src/main/hook/patch/sysinfo.h
+++ b/src/main/hook/patch/sysinfo.h
@@ -1,0 +1,8 @@
+#pragma once
+
+/**
+ * Initialize the patch module
+ *
+ * This takes care of overriding system specs
+ */
+void patch_sysinfo_init();

--- a/src/main/hook/pri/main.c
+++ b/src/main/hook/pri/main.c
@@ -26,6 +26,7 @@
 #include "hook/patch/redir.h"
 #include "hook/patch/sigsegv.h"
 #include "hook/patch/sound.h"
+#include "hook/patch/sysinfo.h"
 #include "hook/patch/usb-emu.h"
 #include "hook/patch/usb-init-fix.h"
 #include "hook/patch/usb-mnt.h"
@@ -149,6 +150,13 @@ static void prihook_patch_gfx_init(struct prihook_options *options)
   if (options->patch.gfx.scaling_mode != PATCH_GFX_SCALE_MODE_INVALID) {
     patch_gfx_scale(options->patch.gfx.scaling_mode);
   }
+}
+
+static void prihook_patch_sysinfo_init(struct prihook_options *options)
+{
+  log_assert(options);
+
+  patch_sysinfo_init();
 }
 
 static void prihook_patch_main_loop_init(struct prihook_options *options)
@@ -283,6 +291,7 @@ void prihook_trap_before_main(int argc, char **argv)
   prihook_fs_redirs_init(&options, game_data_path);
   prihook_patch_fs_mounting_init();
   prihook_patch_gfx_init(&options);
+  prihook_patch_sysinfo_init(&options);
   prihook_patch_main_loop_init(&options);
   prihook_patch_sound_init(&options);
   prihook_patch_sigsegv_init(&options);


### PR DESCRIPTION
Fixes an issue I ran that prevents Prime 1 to run in HD if the amount of RAM is too high or too low. Tested with v1.22 under Docker.

I am passing `options` to `prihook_patch_sysinfo_init` even if it is unused. I will be happy to put the stubbing behind a proper option, or even fake a certain amount of RAM to always run the game in HD even if the total memory is too low.

I am leaving the "allow edits by maintainers" turned on.
