### PR TITLE
Fix for #50 - pro2 not saving service menu changes

### DIFF
--- a/doc/hook/prohook.md
+++ b/doc/hook/prohook.md
@@ -49,7 +49,7 @@ You need two main folders:
 * `game` folder with the following contents
     * All data zip files (e.g. `data0.zip`, `data1.zip`, ..., `encore.zip`)
     * An empty file `FX` (if you run this on a FX or other cabinet with a widescreen monitor)
-* `save ` folder. Contents are generated automatically if empty.
+* `save` folder and `MachineProfile` inside of it . You must create these folders manually, rest of the files will populate themselves. **Without doing so the game will not save settings or high scores between boots.**
 
 ## USB thumb drive/profile support
 Without any patches, the game's way of handling USB thumb drives is incompatible to the kernels of the last years.

--- a/src/main/capnhook/hooklib/redir.c
+++ b/src/main/capnhook/hooklib/redir.c
@@ -205,7 +205,7 @@ static enum cnh_result _cnh_redir_fshook_rename(struct cnh_fshook_irp *irp)
   _cnh_redir_init();
 
   res_old = _cnh_redir_check(irp->rename_old);
-  res_new = _cnh_redir_check(irp->rename_old);
+  res_new = _cnh_redir_check(irp->rename_new);
 
   if (res_old != NULL) {
     irp->rename_old = res_old;


### PR DESCRIPTION
Fix for #50 

Both Pro1 and Pro2 now save Preferences.ini and all other appropriate save files.

HOWEVER

Pro 1, doesn't save machine highscores unless you crate `./save/MachineProfile` manually. The dumb fix is to let people know in the hook guide to create it, smart fix why it is doing this.

Pro2, the machine highscore will throw away the name after reboot (at least when not using USB profile). Score save and display fine.