### PR TITLE
Adds support for the new LXIO

### DIFF
--- a/src/main/hook/nx2/options.c
+++ b/src/main/hook/nx2/options.c
@@ -240,11 +240,9 @@ bool nx2hook_options_init(
       options_opt, NX2HOOK_OPTIONS_STR_PATCH_HOOK_MAIN_LOOP_X11_INPUT_HANDLER);
   options->patch.net.server = util_options_get_str(
       options_opt, NX2HOOK_OPTIONS_STR_PATCH_NET_PROFILE_SERVER);
-  options->patch.net.machine_id = strtoull(
-      util_options_get_str(
-          options_opt, NX2HOOK_OPTIONS_STR_PATCH_NET_PROFILE_MACHINE_ID),
-      NULL,
-      16);
+  const char *machine_id_str = util_options_get_str(
+      options_opt, NX2HOOK_OPTIONS_STR_PATCH_NET_PROFILE_MACHINE_ID);
+  options->patch.net.machine_id = machine_id_str ? strtoull(machine_id_str, NULL, 16) : 0;
   options->patch.net.verbose_log_output = util_options_get_bool(
       options_opt, NX2HOOK_OPTIONS_STR_PATCH_NET_PROFILE_VERBOSE_LOG_OUTPUT);
   options->patch.net.cert_dir_path = util_options_get_str(

--- a/src/main/hook/nxa/options.c
+++ b/src/main/hook/nxa/options.c
@@ -238,11 +238,9 @@ bool nxahook_options_init(
       options_opt, NXAHOOK_OPTIONS_STR_PATCH_HOOK_MAIN_LOOP_X11_INPUT_HANDLER);
   options->patch.net.server = util_options_get_str(
       options_opt, NXAHOOK_OPTIONS_STR_PATCH_NET_PROFILE_SERVER);
-  options->patch.net.machine_id = strtoull(
-      util_options_get_str(
-          options_opt, NXAHOOK_OPTIONS_STR_PATCH_NET_PROFILE_MACHINE_ID),
-      NULL,
-      16);
+  const char *machine_id_str = util_options_get_str(
+      options_opt, NXAHOOK_OPTIONS_STR_PATCH_NET_PROFILE_MACHINE_ID);
+  options->patch.net.machine_id = machine_id_str ? strtoull(machine_id_str, NULL, 16) : 0;
   options->patch.net.verbose_log_output = util_options_get_bool(
       options_opt, NXAHOOK_OPTIONS_STR_PATCH_NET_PROFILE_VERBOSE_LOG_OUTPUT);
   options->patch.net.cert_dir_path = util_options_get_str(

--- a/src/main/io/lxio/defs.h
+++ b/src/main/io/lxio/defs.h
@@ -2,7 +2,8 @@
 #define LXIO_DRV_DEFS_H
 
 #define LXIO_VID 0x0D2F
-#define LXIO_PID 0x1020
+static const int LXIO_PID[] = { 0x1040, 0x1020 };
+#define LXIO_PID_COUNT  (sizeof(LXIO_PID) / sizeof(LXIO_PID[0]))
 
 #define LXIO_DRV_USB_REQ_TIMEOUT 10000
 

--- a/src/main/io/lxio/device.c
+++ b/src/main/io/lxio/device.c
@@ -16,7 +16,12 @@ bool lxio_drv_device_open(void)
     return true;
   }
 
-  lxio_drv_device_handle = io_usb_open(LXIO_VID, LXIO_PID, 1, 0);
+  for( int p = 0; p < LXIO_PID_COUNT; ++p ) {
+    lxio_drv_device_handle = io_usb_open(LXIO_VID, LXIO_PID[p], 1, 0);
+    if( lxio_drv_device_handle ) {
+      break;
+    }
+  }
 
   return lxio_drv_device_handle;
 }

--- a/src/main/ptapi/io/piuio/lxio/lxio.c
+++ b/src/main/ptapi/io/piuio/lxio/lxio.c
@@ -79,6 +79,11 @@ void convert_output_to_lxio()
     lxio_light_state_buffer[1] |= (1 << 2);
   }
 
+  /* enable usb inhibitor and coins, always on */
+  lxio_light_state_buffer[3] |= (1 << 4);
+  lxio_light_state_buffer[3] |= (1 << 5);
+  lxio_light_state_buffer[3] |= (1 << 6);
+
   /* Halogens */
 
   if (ptapi_piuio_cab_out.halo_r1) {

--- a/src/main/ptapi/io/piuio/lxio/lxio.c
+++ b/src/main/ptapi/io/piuio/lxio/lxio.c
@@ -79,10 +79,15 @@ void convert_output_to_lxio()
     lxio_light_state_buffer[1] |= (1 << 2);
   }
 
+  /* coin counter 1 */
+  if(ptapi_piuio_sys.coin) {
+    lxio_light_state_buffer[3] |= (1 << 3);
+  }
+
   /* enable usb inhibitor and coins, always on */
-  lxio_light_state_buffer[3] |= (1 << 4);
-  lxio_light_state_buffer[3] |= (1 << 5);
-  lxio_light_state_buffer[3] |= (1 << 6);
+  lxio_light_state_buffer[3] |= (1 << 4); // usb enable
+  lxio_light_state_buffer[3] |= (1 << 5); // coin1
+  lxio_light_state_buffer[3] |= (1 << 6); // coin2
 
   /* Halogens */
 


### PR DESCRIPTION
PR does 3 things

- New cabinets ship an LXIO which uses a product ID of 0x1040, they are functionally equivalent. This tries to use that device, if it fails it falls back to 0x1020.

- Enables the USB inhibitor and coins 12v output.

- Fixes an issue with with nx1 and nx2 crashing if you have `patch.net_profile.machine_id=` empty in your hook.
