### PR TITLE
Pro 2 Hook: USB ports can now be assigned in config file the same way as in Pro 1

### DIFF
--- a/cmake/src/main/hook/pro2/CMakeLists.txt
+++ b/cmake/src/main/hook/pro2/CMakeLists.txt
@@ -12,4 +12,4 @@ add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-fPIC")
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 
-target_link_libraries(${PROJECT_NAME} hook-core patch ptapi-io-piuio-util util dl pthread)
+target_link_libraries(${PROJECT_NAME} hook-core patch propatch ptapi-io-piuio-util util dl pthread)

--- a/dist/conf/pro2hook.conf
+++ b/dist/conf/pro2hook.conf
@@ -25,6 +25,15 @@ patch.piuio.emu_lib=
 # [bool (0/1)]: Enable game exit on Test + Service
 patch.piuio_exit.test_serv=0
 
+# [str]: Bus and port (format: X-X, e.g. 1-2) of the USB slot to assign to Player 1 when a USB thumb drive is plugged in
+patch.usb_profile.p1.bus_port=
+
+# [str]: Bus and port (format: X-X, e.g. 1-2) of the USB slot to assign to Player 2 when a USB thumb drive is plugged in
+patch.usb_profile.p2.bus_port=
+
+# [str]: Device nodes of plugged in USB thumb drives to consider for mounting for usb profiles, format: sdX,sdY e.g. sde,sdf
+patch.usb_profile.dev_nodes=
+
 # [str]: Path to a library implementing the x11-input-handler api to capture X11 keyboard inputs
 patch_x11_event_loop.input_handler_lib=
 

--- a/doc/hook/pro2hook.md
+++ b/doc/hook/pro2hook.md
@@ -64,6 +64,28 @@ Each folder with the content from the dump.
 ## USB thumb drive/profile support
 See instructions on the [prohook readme](prohook.md#usb-thumb-driveprofile-support).
 
+When using `pro2hook.so`, make sure your `hook.conf` contains the same USB
+profile keys used by Pro 1:
+
+```text
+patch.usb_profile.p1.bus_port=2-1
+patch.usb_profile.p2.bus_port=2-2
+patch.usb_profile.dev_nodes=sdb,sdc
+```
+
+Additionally these settings in `Static.ini` must be set as follows:
+```text
+MemoryCardProfiles=1
+MemoryCardUsbBusP1=-1
+MemoryCardUsbBusP2=-1
+MemoryCardUsbLevelP1=1
+MemoryCardUsbLevelP2=1
+MemoryCardUsbPortP1=2
+MemoryCardUsbPortP2=1
+```
+The file is located in `game/Data/Static.ini`.
+When this is not set, the first plugged USB thumb drive will always be connected to Player 1, no matter what port it is connected into.
+
 ## Troubleshooting and FAQ
 Since the game is based on Pro 1, have a look at the
 [troubleshooting section there](19-pro.md#troubleshooting-and-faq). Most of the things listed there

--- a/src/main/hook/pro2/main.c
+++ b/src/main/hook/pro2/main.c
@@ -19,6 +19,8 @@
 #include "hook/patch/usb-init-fix.h"
 #include "hook/patch/x11-event-loop.h"
 
+#include "hook/propatch/usb-fix.h"
+
 #include "hook/patch/piubtn.h"
 #include "hook/patch/piuio.h"
 
@@ -160,6 +162,14 @@ static void pro2hook_patch_x11_event_loop_init(struct pro2hook_options *options)
   }
 }
 
+static void pro2hook_patch_usbprofiles(struct pro2hook_options *options)
+{
+  propatch_usb_fix_init(
+      options->patch.usb_profile.device_nodes,
+      options->patch.usb_profile.p1_bus_port,
+      options->patch.usb_profile.p2_bus_port);
+}
+
 static void pro2hook_patch_piuio_init(struct pro2hook_options *options)
 {
   log_assert(options);
@@ -236,6 +246,7 @@ void pro2hook_trap_before_main(int argc, char **argv)
   pro2hook_fs_redirs_init(&options);
   pro2hook_patch_sigsegv_init(&options);
   pro2hook_patch_x11_event_loop_init(&options);
+  pro2hook_patch_usbprofiles(&options);
   pro2hook_patch_piuio_init(&options);
   pro2hook_patch_piubtn_init(&options);
   pro2hook_patch_secure_binary();
@@ -245,6 +256,7 @@ void pro2hook_trap_before_main(int argc, char **argv)
 
 void pro2hook_trap_after_main(void)
 {
+  propatch_usb_fix_shutdown();
   patch_piubtn_shutdown();
   patch_piuio_shutdown();
 }

--- a/src/main/hook/pro2/options.c
+++ b/src/main/hook/pro2/options.c
@@ -12,6 +12,12 @@
 #define PRO2HOOK_OPTIONS_STR_PATCH_PIUIO_EMU_LIB "patch.piuio.emu_lib"
 #define PRO2HOOK_OPTIONS_STR_PATCH_PIUIO_EXIT_TEST_SERV \
   "patch.piuio_exit.test_serv"
+#define PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P1_BUS_PORT \
+    "patch.usb_profile.p1.bus_port"
+#define PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P2_BUS_PORT \
+    "patch.usb_profile.p2.bus_port"
+#define PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_DEV_NODES \
+    "patch.usb_profile.dev_nodes"
 #define PRO2HOOK_OPTIONS_STR_PATCH_X11_EVENT_LOOP_INPUT_HANDLER \
   "patch_x11_event_loop.input_handler_lib"
 #define PRO2HOOK_OPTIONS_STR_PATCH_X11_EVENT_LOOP_INPUT_HANDLER2 \
@@ -95,6 +101,36 @@ const struct util_options_def pro2hook_options_def[] = {
         .default_value.b = false,
     },
     {
+        .name = PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P1_BUS_PORT,
+        .description = "Bus and port (format: X-X, e.g. 1-2) of the USB slot "
+                       "to assign to Player 1 when a USB thumb "
+                       "drive is plugged in",
+        .param = 'a',
+        .type = UTIL_OPTIONS_TYPE_STR,
+        .is_secret_data = false,
+        .default_value.str = NULL,
+    },
+    {
+        .name = PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P2_BUS_PORT,
+        .description = "Bus and port (format: X-X, e.g. 1-2) of the USB slot "
+                       "to assign to Player 2 when a USB thumb "
+                       "drive is plugged in",
+        .param = 'k',
+        .type = UTIL_OPTIONS_TYPE_STR,
+        .is_secret_data = false,
+        .default_value.str = NULL,
+    },
+    {
+        .name = PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_DEV_NODES,
+        .description = "Device nodes of plugged in USB thumb drives to "
+                       "consider for mounting for usb profiles, format: "
+                       "sdX,sdY e.g. sde,sdf",
+        .param = 't',
+        .type = UTIL_OPTIONS_TYPE_STR,
+        .is_secret_data = false,
+        .default_value.str = NULL,
+    },
+    {
         .name = PRO2HOOK_OPTIONS_STR_PATCH_X11_EVENT_LOOP_INPUT_HANDLER,
         .description = "Path to a library implementing the x11-input-handler "
                        "api to capture X11 keyboard inputs",
@@ -172,6 +208,12 @@ bool pro2hook_options_init(
       options_opt, PRO2HOOK_OPTIONS_STR_PATCH_PIUIO_EMU_LIB);
   options->patch.piuio.exit_test_serv = util_options_get_bool(
       options_opt, PRO2HOOK_OPTIONS_STR_PATCH_PIUIO_EXIT_TEST_SERV);
+  options->patch.usb_profile.device_nodes = util_options_get_str(
+      options_opt, PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_DEV_NODES);
+  options->patch.usb_profile.p1_bus_port = util_options_get_str(
+      options_opt, PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P1_BUS_PORT);
+  options->patch.usb_profile.p2_bus_port = util_options_get_str(
+      options_opt, PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P2_BUS_PORT);
   options->patch.x11_event_loop.api_lib = util_options_get_str(
       options_opt, PRO2HOOK_OPTIONS_STR_PATCH_X11_EVENT_LOOP_INPUT_HANDLER);
   options->patch.x11_event_loop.api_lib2 = util_options_get_str(

--- a/src/main/hook/pro2/options.h
+++ b/src/main/hook/pro2/options.h
@@ -29,6 +29,12 @@ struct pro2hook_options {
       bool exit_test_serv;
     } piuio;
 
+    struct usb_profile {
+      const char *device_nodes;
+      const char *p1_bus_port;
+      const char *p2_bus_port;
+    } usb_profile;
+
     struct x11_event_loop {
       const char *api_lib;
       const char *api_lib2;


### PR DESCRIPTION
Basically the title.

Every time I am at my machine I play Pro 2, however since it has been a longer time since I did work on fixing other stuff in pumptools I was surprised that I have to plug in two USB sticks to have a profile on P2 side. Turns out it was never implemented. 

This is basically 1:1 copied over from Pro 1 hook, with copilot going over it as a sanity check.

I will test it over the weekend. 

Edit: (This will be compiled and tested in tandem with #72 #71 #69 and #68 which may or may not be necessary.)