### PR TITLE
Mk3 fixes

### DIFF
--- a/src/main/capnhook/hooklib/usb-emu.c
+++ b/src/main/capnhook/hooklib/usb-emu.c
@@ -243,7 +243,7 @@ _cnh_usb_emu_usbhook_find_devices(struct cnh_usbhook_irp *irp)
         /* Append at end of bus chain */
         it->next = fakebus;
         /* Keep doubly linked list intact */
-        fakebus->prev = it->next;
+        fakebus->prev = it;
       }
 
       fakebus_dev_tail = NULL;

--- a/src/main/hook/mk3/main.c
+++ b/src/main/hook/mk3/main.c
@@ -22,6 +22,7 @@
 #include "hook/patch/sigsegv.h"
 #include "hook/patch/sound.h"
 #include "hook/patch/usb-emu.h"
+#include "hook/patch/usb-init-fix.h"
 
 #include "util/fs.h"
 #include "util/glibc.h"
@@ -195,6 +196,7 @@ static void mk3hook_patch_piuio_init(struct mk3hook_options *options)
     patch_piuio_exit_init();
   }
 
+  patch_usb_init_fix_init();
   patch_usb_emu_init();
 
   if (options->patch.piuio.api_lib) {


### PR DESCRIPTION
I was able to get all of the MK3 games to work except:
* 1st - it either crashes on AM logo or if I get to service menu it stops receiving input
* 2nd - It will allow me to do two inputs from title screen, then it stops communicating with IO, after game over I can yet again do two inputs
* Extra - has no input with IO

OBG, Premiere, Prex2beta were setup incorrectly and have to be retested.

So far I am more so just checking and poking around, Im not sure if this is the actual cause. 


Edit:
Tested as is. Works on all MK3 games without any issues. It did not fix anything regarding 1st, 2nd or Extra. 

Those are still a mystery. I did let copilot try to fix it and I was able to boot both 1st and 2nd successfully, however they were jittery and sometimes some assets didn't load properly. Since it did not really fix the issues and I am not able to validate the changes, I will not release that just yet. I would need some more help with that.

Extra didn't budge at all, still only registering F1 and F2.