### PR TITLE
emu_lib files anywhere

### DIFF
--- a/src/main/ptapi/io/piubtn/joystick/joystick.c
+++ b/src/main/ptapi/io/piubtn/joystick/joystick.c
@@ -60,6 +60,21 @@ bool ptapi_io_piubtn_open()
   struct io_util_joystick_util_device_info device_info[MAX_NUM_JOYSTICKS];
   size_t devices_connected;
 
+  if (util_proc_get_folder_path_shared_object(
+          (void *) ptapi_io_piubtn_open, path, sizeof(path))) {
+    config_path = util_str_merge(path, CONFIG_FILENAME);
+
+    log_info("Loading configuration from emu lib path: %s", config_path);
+
+    if (ptapi_io_piubtn_joystick_util_conf_read_from_file(
+            &ptapi_io_piubtn_joystick_util_conf, config_path)) {
+      free(config_path);
+      goto conf_loaded;
+    }
+
+    free(config_path);
+  }
+
   // The game changes the working directory to the 'game' sub-folder. Therefore,
   // ./my-config does not work here.
   if (!util_proc_get_folder_path_executable_no_ld_linux(path, sizeof(path))) {
@@ -69,6 +84,8 @@ bool ptapi_io_piubtn_open()
 
   config_path = util_str_merge(path, CONFIG_FILENAME);
 
+  log_info("Loading configuration from executable path: %s", config_path);
+
   if (!ptapi_io_piubtn_joystick_util_conf_read_from_file(
           &ptapi_io_piubtn_joystick_util_conf, config_path)) {
     log_error("Loading joystick config file %s failed.", CONFIG_FILENAME);
@@ -77,6 +94,8 @@ bool ptapi_io_piubtn_open()
   }
 
   free(config_path);
+
+conf_loaded:
 
   devices_connected =
       io_util_joystick_util_scan(device_info, MAX_NUM_JOYSTICKS);

--- a/src/main/ptapi/io/piubtn/keyboard/keyboard.c
+++ b/src/main/ptapi/io/piubtn/keyboard/keyboard.c
@@ -48,6 +48,22 @@ bool ptapi_io_piubtn_open()
   char path[PATH_MAX];
   char *config_path;
 
+  if (util_proc_get_folder_path_shared_object(
+          (void *) ptapi_io_piubtn_open, path, sizeof(path))) {
+    config_path = util_str_merge(path, CONFIG_FILENAME);
+
+    log_info("Loading configuration from emu lib path: %s", config_path);
+
+    if (ptapi_io_piubtn_keyboard_util_conf_read_from_file(
+            &ptapi_io_piubtn_keyboard_conf, config_path)) {
+      free(config_path);
+      memset(ptapi_io_piubtn_keyboard_buffer, 0, sizeof(bool) * KEY_MAP_SIZE);
+      return true;
+    }
+
+    free(config_path);
+  }
+
   // The game changes the working directory to the 'game' sub-folder. Therefore,
   // ./my-config does not work here.
   if (!util_proc_get_folder_path_executable_no_ld_linux(path, sizeof(path))) {
@@ -56,6 +72,8 @@ bool ptapi_io_piubtn_open()
   }
 
   config_path = util_str_merge(path, CONFIG_FILENAME);
+
+  log_info("Loading configuration from executable path: %s", config_path);
 
   if (!ptapi_io_piubtn_keyboard_util_conf_read_from_file(
           &ptapi_io_piubtn_keyboard_conf, config_path)) {

--- a/src/main/ptapi/io/piuio/joystick/joystick.c
+++ b/src/main/ptapi/io/piuio/joystick/joystick.c
@@ -60,6 +60,21 @@ bool ptapi_io_piuio_open()
   struct io_util_joystick_util_device_info device_info[MAX_NUM_JOYSTICKS];
   size_t devices_connected;
 
+  if (util_proc_get_folder_path_shared_object(
+          (void *) ptapi_io_piuio_open, path, sizeof(path))) {
+    config_path = util_str_merge(path, CONFIG_FILENAME);
+
+    log_info("Loading configuration from emu lib path: %s", config_path);
+
+    if (ptapi_io_piuio_joystick_util_conf_read_from_file(
+            &ptapi_io_piuio_joystick_util_conf, config_path)) {
+      free(config_path);
+      goto conf_loaded;
+    }
+
+    free(config_path);
+  }
+
   // The game changes the working directory to the 'game' sub-folder. Therefore,
   // ./my-config does not work here.
   if (!util_proc_get_folder_path_executable_no_ld_linux(path, sizeof(path))) {
@@ -69,7 +84,7 @@ bool ptapi_io_piuio_open()
 
   config_path = util_str_merge(path, CONFIG_FILENAME);
 
-  log_info("Loading configuration: ", config_path);
+  log_info("Loading configuration from executable path: %s", config_path);
 
   if (!ptapi_io_piuio_joystick_util_conf_read_from_file(
           &ptapi_io_piuio_joystick_util_conf, config_path)) {
@@ -79,6 +94,8 @@ bool ptapi_io_piuio_open()
   }
 
   free(config_path);
+
+conf_loaded:
 
   devices_connected =
       io_util_joystick_util_scan(device_info, MAX_NUM_JOYSTICKS);

--- a/src/main/ptapi/io/piuio/keyboard/keyboard.c
+++ b/src/main/ptapi/io/piuio/keyboard/keyboard.c
@@ -47,6 +47,22 @@ bool ptapi_io_piuio_open()
   char path[PATH_MAX];
   char *config_path;
 
+  if (util_proc_get_folder_path_shared_object(
+          (void *) ptapi_io_piuio_open, path, sizeof(path))) {
+    config_path = util_str_merge(path, CONFIG_FILENAME);
+
+    log_info("Loading configuration from emu lib path: %s", config_path);
+
+    if (ptapi_io_piuio_keyboard_util_conf_read_from_file(
+            &ptapi_io_piuio_keyboard_conf, config_path)) {
+      free(config_path);
+      memset(ptapi_io_piuio_keyboard_buffer, 0, sizeof(bool) * KEY_MAP_SIZE);
+      return true;
+    }
+
+    free(config_path);
+  }
+
   // The game changes the working directory to the 'game' sub-folder. Therefore,
   // ./my-config does not work here.
   if (!util_proc_get_folder_path_executable_no_ld_linux(path, sizeof(path))) {
@@ -56,7 +72,7 @@ bool ptapi_io_piuio_open()
 
   config_path = util_str_merge(path, CONFIG_FILENAME);
 
-  log_info("Loading configuration: ", config_path);
+  log_info("Loading configuration from executable path: %s", config_path);
 
   if (!ptapi_io_piuio_keyboard_util_conf_read_from_file(
           &ptapi_io_piuio_keyboard_conf, config_path)) {

--- a/src/main/util/fs.c
+++ b/src/main/util/fs.c
@@ -210,15 +210,39 @@ char *util_fs_get_filename(const char *path)
 
 char *util_fs_get_abs_path(const char *path)
 {
+  size_t path_len;
   char *real_path;
+
+  if (!path) {
+    return NULL;
+  }
+
+  path_len = strlen(path);
+
+  if (path_len == 0) {
+    real_path = (char *) util_xmalloc(1);
+    real_path[0] = '\0';
+    return real_path;
+  }
+
+  /* Keep explicit absolute paths untouched to support external mount points. */
+  if (path[0] == '/') {
+    real_path = (char *) util_xmalloc(path_len + 1);
+    memcpy(real_path, path, path_len + 1);
+    return real_path;
+  }
 
   real_path = realpath(path, NULL);
 
   if (!real_path) {
-    log_error(
+    log_warn(
         "Resolving path '%s' to absolute path failed: %s",
         path,
         strerror(errno));
+
+    /* Fall back to the original path and let the dynamic loader resolve it. */
+    real_path = (char *) util_xmalloc(path_len + 1);
+    memcpy(real_path, path, path_len + 1);
   }
 
   return real_path;

--- a/src/main/util/proc.c
+++ b/src/main/util/proc.c
@@ -1,5 +1,6 @@
 #define LOG_MODULE "util-proc"
 
+#include <dlfcn.h>
 #include <errno.h>
 #include <linux/limits.h>
 #include <string.h>
@@ -203,6 +204,40 @@ bool util_proc_get_folder_path_executable_no_ld_linux(char *buffer, size_t size)
   } else {
     return util_proc_get_folder_path_executable(buffer, size);
   }
+}
+
+bool util_proc_get_folder_path_shared_object(
+    void *symbol, char *buffer, size_t size)
+{
+  Dl_info info;
+
+  if (!symbol || !buffer || size == 0) {
+    return false;
+  }
+
+  if (!dladdr(symbol, &info) || !info.dli_fname) {
+    return false;
+  }
+
+  if (strlen(info.dli_fname) >= size) {
+    return false;
+  }
+
+  strcpy(buffer, info.dli_fname);
+
+  // If shared object in the root folder, keep the single /
+  size_t pos = strlen(buffer) - 1;
+  while (pos > 0 && buffer[pos] != '/') {
+    buffer[pos] = '\0';
+    pos--;
+  }
+
+  // delete /
+  if (pos > 0) {
+    buffer[pos] = '\0';
+  }
+
+  return true;
 }
 
 void util_proc_log_info()

--- a/src/main/util/proc.h
+++ b/src/main/util/proc.h
@@ -44,6 +44,18 @@ bool util_proc_get_folder_path_executable_no_ld_linux(
     char *buffer, size_t size);
 
 /**
+ * Get the full path of the folder of the shared object that contains the
+ * supplied symbol.
+ *
+ * @param symbol Pointer to any symbol in the target shared object.
+ * @param buffer Buffer to read the path into.
+ * @param size Size of the buffer.
+ * @return True on success, false on failure.
+ */
+bool util_proc_get_folder_path_shared_object(
+    void *symbol, char *buffer, size_t size);
+
+/**
  * Log information about the current process to the console.
  */
 void util_proc_log_info();


### PR DESCRIPTION
The piuio and btnio files can now be placed anywhere and the path provided in the config file will be parsed correctly.

For the keyboard/joystick, the bin conf file can be placed either beside the appropriate `piuio/btnio-keyboard.so` or next to the `piu` executable (the name of the conf bin has to be unchanged).

This is not an issue if you are running just one or two games, but once you run the odd 30ish it becomes a headache keeping all of them up to date and or if you change your keybinds, having to update the file in every single folder. 