### PR TITLE
Fiesta2 profile fix

### DIFF
--- a/cmake/src/main/hook/pro2/CMakeLists.txt
+++ b/cmake/src/main/hook/pro2/CMakeLists.txt
@@ -12,4 +12,4 @@ add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-fPIC")
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 
-target_link_libraries(${PROJECT_NAME} hook-core patch ptapi-io-piuio-util util dl pthread)
+target_link_libraries(${PROJECT_NAME} hook-core patch propatch ptapi-io-piuio-util util dl pthread)

--- a/dist/conf/pro2hook.conf
+++ b/dist/conf/pro2hook.conf
@@ -25,6 +25,15 @@ patch.piuio.emu_lib=
 # [bool (0/1)]: Enable game exit on Test + Service
 patch.piuio_exit.test_serv=0
 
+# [str]: Bus and port (format: X-X, e.g. 1-2) of the USB slot to assign to Player 1 when a USB thumb drive is plugged in
+patch.usb_profile.p1.bus_port=
+
+# [str]: Bus and port (format: X-X, e.g. 1-2) of the USB slot to assign to Player 2 when a USB thumb drive is plugged in
+patch.usb_profile.p2.bus_port=
+
+# [str]: Device nodes of plugged in USB thumb drives to consider for mounting for usb profiles, format: sdX,sdY e.g. sde,sdf
+patch.usb_profile.dev_nodes=
+
 # [str]: Path to a library implementing the x11-input-handler api to capture X11 keyboard inputs
 patch_x11_event_loop.input_handler_lib=
 

--- a/doc/hook/pro2hook.md
+++ b/doc/hook/pro2hook.md
@@ -64,6 +64,28 @@ Each folder with the content from the dump.
 ## USB thumb drive/profile support
 See instructions on the [prohook readme](prohook.md#usb-thumb-driveprofile-support).
 
+When using `pro2hook.so`, make sure your `hook.conf` contains the same USB
+profile keys used by Pro 1:
+
+```text
+patch.usb_profile.p1.bus_port=2-1
+patch.usb_profile.p2.bus_port=2-2
+patch.usb_profile.dev_nodes=sdb,sdc
+```
+
+Additionally these settings in `Static.ini` must be set as follows:
+```text
+MemoryCardProfiles=1
+MemoryCardUsbBusP1=-1
+MemoryCardUsbBusP2=-1
+MemoryCardUsbLevelP1=1
+MemoryCardUsbLevelP2=1
+MemoryCardUsbPortP1=2
+MemoryCardUsbPortP2=1
+```
+The file is located in `game/Data/Static.ini`.
+When this is not set, the first plugged USB thumb drive will always be connected to Player 1, no matter what port it is connected into.
+
 ## Troubleshooting and FAQ
 Since the game is based on Pro 1, have a look at the
 [troubleshooting section there](19-pro.md#troubleshooting-and-faq). Most of the things listed there

--- a/doc/hook/pro2hook.md
+++ b/doc/hook/pro2hook.md
@@ -64,6 +64,15 @@ Each folder with the content from the dump.
 ## USB thumb drive/profile support
 See instructions on the [prohook readme](prohook.md#usb-thumb-driveprofile-support).
 
+When using `pro2hook.so`, make sure your `hook.conf` contains the same USB
+profile keys used by Pro 1:
+
+```text
+patch.usb_profile.p1.bus_port=2-1
+patch.usb_profile.p2.bus_port=2-2
+patch.usb_profile.dev_nodes=sdb,sdc
+```
+
 ## Troubleshooting and FAQ
 Since the game is based on Pro 1, have a look at the
 [troubleshooting section there](19-pro.md#troubleshooting-and-faq). Most of the things listed there

--- a/src/main/asset/nx2/tool/usb-profile.c
+++ b/src/main/asset/nx2/tool/usb-profile.c
@@ -4,155 +4,370 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
+#include <limits.h>
 
 #include "asset/nx2/lib/util.h"
+#include "asset/nx2/lib/usb-save.h"
 
+#include "util/fs.h"
 #include "util/str.h"
 
 int main(int argc, char **argv)
 {
-  int ret;
-  char *rank_path;
-  char *save_path;
+  int ret = 0;
+  char *rank_path_encrypted;
+  char *save_path_encrypted;
+  char *rank_path_decrypted;
+  char *save_path_decrypted;
 
-  if (argc < 3) {
+  struct asset_nx2_usb_rank *rank = NULL;
+  struct asset_nx2_usb_save *save = NULL;
+
+  if (argc < 2 || argc > 3)
+  {
+    printf("Usage: %s help\n", argv[0]);
+    return -1;
+  }
+
+  if (!strcmp(argv[1], "help"))
+  {
     printf(
-        "Usage: %s [cmd: new, dec, enc, dump] "
-        "[path containing nx2rank.bin nx2save.bin]\n",
+        "Usage: %s [COMMAND] <Option> (Directory)\n\n"
+        "Commands:\n"
+        "  [new] - Create new default profile files\n"
+        "  [dec] - Decrypt existing profile files\n"
+        "  [enc] - Encrypt existing decrypted profile files\n"
+        "  [dump] - Print existing profile files to txt\n"
+        "  [edit] - Edit player name, avatar, and mileage in profile files\n"
+        "  [help] - Show this help message\n\n"
+        "(Directory) - Directory containing nx2rank.bin.dec nx2save.bin.dec\n"
+        "\n",
         argv[0]);
     return -1;
   }
 
-  ret = 0;
+  if (argc == 3)
+  {
+    const char *base = argv[argc - 1];
+    size_t blen = strlen(base);
+    int has_slash = (blen > 0 && base[blen - 1] == '/');
 
-  rank_path = util_str_merge(argv[2], "nx2rank.bin");
-  save_path = util_str_merge(argv[2], "nx2save.bin");
+    if (has_slash) {
+      rank_path_encrypted = util_str_merge(base, "nx2rank.bin");
+      save_path_encrypted = util_str_merge(base, "nx2save.bin");
+      rank_path_decrypted = util_str_merge(base, "nx2rank.dec");
+      save_path_decrypted = util_str_merge(base, "nx2save.dec");
+    } else {
+      rank_path_encrypted = util_str_merge(base, "/nx2rank.bin");
+      save_path_encrypted = util_str_merge(base, "/nx2save.bin");
+      rank_path_decrypted = util_str_merge(base, "/nx2rank.dec");
+      save_path_decrypted = util_str_merge(base, "/nx2save.dec");
+    }
+  }
+  else
+  {
+    rank_path_encrypted = strdup("nx2rank.bin");
+    save_path_encrypted = strdup("nx2save.bin");
+    rank_path_decrypted = strdup("nx2rank.dec");
+    save_path_decrypted = strdup("nx2save.dec");
+  }
 
-  if (!strcmp(argv[1], "new")) {
+  if(!strcmp(argv[1], "new"))
+  {
+
     struct asset_nx2_usb_rank *rank = asset_nx2_usb_rank_new();
     struct asset_nx2_usb_save *save = asset_nx2_usb_save_new();
 
     asset_nx2_usb_rank_finalize(rank);
     asset_nx2_usb_save_finalize(save);
 
-    if (!asset_nx2_usb_rank_save_to_file(rank_path, rank, true)) {
-      fprintf(stderr, "Creating rank file %s failed\n", rank_path);
+    if (!asset_nx2_usb_rank_save_to_file(rank_path_encrypted, rank, true)) {
+      fprintf(stderr, "Creating rank file %s failed\n", rank_path_encrypted);
       ret = -2;
     }
 
-    if (!asset_nx2_usb_save_save_to_file(save_path, save, true)) {
-      fprintf(stderr, "Creating save file %s failed\n", save_path);
+    if (!asset_nx2_usb_save_save_to_file(save_path_encrypted, save, true)) {
+      fprintf(stderr, "Creating save file %s failed\n", save_path_encrypted);
       ret = -3;
     }
 
     free(rank);
     free(save);
-  } else {
-    struct asset_nx2_usb_rank *rank;
-    struct asset_nx2_usb_save *save;
-    bool encrypted;
 
-    if (!strcmp(argv[1], "enc")) {
-      char *tmp;
+  } else if (!strcmp(argv[1], "dec"))
+    {
+  
+      rank = asset_nx2_usb_rank_load_from_file(rank_path_encrypted, true);
+      save = asset_nx2_usb_save_load_from_file(save_path_encrypted, true);
+  
+      if (!rank) {
+        fprintf(stderr, "Loading %s failed\n", rank_path_encrypted);
+        ret = -4;
+      } else if (!save) {
+        fprintf(stderr, "Loading %s failed\n", save_path_encrypted);
+        ret = -5;
+        free(rank);
+      } else {
+  
+        if (!asset_nx2_usb_rank_save_to_file(rank_path_decrypted, rank, false)) {
+          fprintf(stderr, "Saving decrypted rank file to %s failed\n", rank_path_decrypted);
+          ret = -6;
+        }
+  
+        if (!asset_nx2_usb_save_save_to_file(save_path_decrypted, save, false)) {
+          fprintf(stderr, "Saving decrypted save file to %s failed\n", save_path_decrypted);
+          ret = -7;
+        }
 
-      encrypted = false;
-
-      tmp = util_str_merge(rank_path, ".dec");
-      free(rank_path);
-      rank_path = tmp;
-
-      tmp = util_str_merge(save_path, ".dec");
-      free(save_path);
-      save_path = tmp;
-    } else {
-      encrypted = true;
+        ret = 0;
+      }
     }
+    else if (!strcmp(argv[1], "enc"))
+    {
+    
+      rank = asset_nx2_usb_rank_load_from_file(rank_path_decrypted, false);
+      save = asset_nx2_usb_save_load_from_file(save_path_decrypted, false);
+      
+      {
+        if (util_fs_path_exists(rank_path_encrypted)) {
+          char *rank_old = util_str_merge(rank_path_encrypted, "_old");
+          if (rename(rank_path_encrypted, rank_old) != 0) {
+            fprintf(stderr, "Renaming %s to %s failed\n", rank_path_encrypted, rank_old);
+          }
+          free(rank_old);
+        }
 
-    rank = asset_nx2_usb_rank_load_from_file(rank_path, encrypted);
-    save = asset_nx2_usb_save_load_from_file(save_path, encrypted);
+        if (util_fs_path_exists(save_path_encrypted)) {
+          char *save_old = util_str_merge(save_path_encrypted, "_old");
+          if (rename(save_path_encrypted, save_old) != 0) {
+            fprintf(stderr, "Renaming %s to %s failed\n", save_path_encrypted, save_old);
+          }
+          free(save_old);
+        }
+      }
 
-    if (!rank) {
-      fprintf(stderr, "Loading %s failed", rank_path);
-      ret = -4;
-      goto cleanup;
-    }
-
-    if (!save) {
-      fprintf(stderr, "Loading %s failed", save_path);
-      ret = -5;
-      free(rank);
-      goto cleanup;
-    }
-
-    if (!strcmp(argv[1], "dec")) {
-      char *rank_path_dec;
-      char *save_path_dec;
-
-      rank_path_dec = util_str_merge(rank_path, ".dec");
-      save_path_dec = util_str_merge(save_path, ".dec");
-
-      if (!asset_nx2_usb_rank_save_to_file(rank_path_dec, rank, false)) {
+      if (!asset_nx2_usb_rank_save_to_file(rank_path_encrypted, rank, true)) {
         fprintf(
-            stderr, "Saving decrypted rank file to %s failed\n", rank_path_dec);
+            stderr, "Saving encrypted rank file to %s failed\n", rank_path_encrypted);
         ret = -6;
       }
 
-      if (!asset_nx2_usb_save_save_to_file(save_path_dec, save, false)) {
+      if (!asset_nx2_usb_save_save_to_file(save_path_encrypted, save, true)) {
         fprintf(
-            stderr, "Saving decrypted save file to %s failed\n", save_path_dec);
+            stderr, "Saving encrypted save file to %s failed\n", save_path_encrypted);
         ret = -7;
       }
-
-      free(rank_path_dec);
-      free(save_path_dec);
-    } else if (!strcmp(argv[1], "enc")) {
-      char *rank_path_enc;
-      char *save_path_enc;
-
-      rank_path_enc = util_str_merge(rank_path, ".enc");
-      save_path_enc = util_str_merge(save_path, ".enc");
-
-      if (!asset_nx2_usb_rank_save_to_file(rank_path_enc, rank, true)) {
-        fprintf(
-            stderr, "Saving encrypted rank file to %s failed\n", rank_path_enc);
-        ret = -6;
+  
+      ret = 0;
+    }
+    else if (!strcmp(argv[1], "dump"))
+    {
+      rank = asset_nx2_usb_rank_load_from_file(rank_path_decrypted, false);
+      save = asset_nx2_usb_save_load_from_file(save_path_decrypted, false);
+      
+      if (!rank) {
+        fprintf(stderr, "Loading %s failed\n", rank_path_decrypted);
+        ret = -4;
+        free(save);
+        goto cleanup;
       }
-
-      if (!asset_nx2_usb_save_save_to_file(save_path_enc, save, true)) {
-        fprintf(
-            stderr, "Saving encrypted save file to %s failed\n", save_path_enc);
-        ret = -7;
+      if (!save) {
+        fprintf(stderr, "Loading %s failed\n", save_path_encrypted);
+        ret = -5;
+        free(rank);
+        goto cleanup;
       }
-
-      free(rank_path_enc);
-      free(save_path_enc);
-    } else if (!strcmp(argv[1], "dump")) {
+      
       char *rank_str;
       char *save_str;
-
       rank_str = asset_nx2_usb_rank_to_string(rank);
       save_str = asset_nx2_usb_save_to_string(save);
 
-      printf(
-          "----------------- rank -----------------\n"
-          "%s----------------- save -----------------\n%s",
-          rank_str,
-          save_str);
+      char *dump_path = util_str_merge(rank_path_decrypted, ".dump.txt");
+      
+      char *header1 = "----------------- rank -----------------\n";
+      char *header2 = "----------------- save -----------------\n";
+      
+      size_t total_len = strlen(header1) + strlen(rank_str) + strlen(header2) + strlen(save_str) + 1;
+      char *dump_content = malloc(total_len);
+      
+      if (!dump_content) {
+        fprintf(stderr, "Memory allocation failed for dump content\n");
+        ret = -8;
+      } else {
+        snprintf(dump_content, total_len, "%s%s%s%s", header1, rank_str, header2, save_str);
+        
+        if (!util_file_save(dump_path, dump_content, strlen(dump_content))) {
+          fprintf(stderr, "Failed to save dump file %s\n", dump_path);
+          ret = -8;
+        } else {
+          printf("Profile data dumped to %s\n", dump_path);
+        }
+        
+        free(dump_content);
+      }
 
+      free(dump_path);
       free(rank_str);
       free(save_str);
+
+      ret = 0;
+    } else if(!strcmp(argv[1], "edit")) 
+    {
+
+      rank = asset_nx2_usb_rank_load_from_file(rank_path_encrypted, true);
+      save = asset_nx2_usb_save_load_from_file(save_path_encrypted, true);
+
+      if (!rank) {
+        fprintf(stderr, "Loading %s failed\n", rank_path_encrypted);
+        ret = -4;
+        free(save);
+        goto cleanup;
+      }
+      if (!save) {
+        fprintf(stderr, "Loading %s failed\n", save_path_encrypted);
+        ret = -5;
+        free(rank);
+        goto cleanup;
+      }
+
+      printf("Current player name: %s\n", save->review.player_id);
+      printf("Enter new player name (max 8 characters, A-Z 0-9 only, leave blank to keep current): ");
+      char new_player_name[9];
+      fgets(new_player_name, sizeof(new_player_name), stdin);
+      new_player_name[strcspn(new_player_name, "\n")] = 0;
+
+      size_t len = strlen(new_player_name);
+      if (len > 8) {
+        fprintf(stderr, "Error: Player name must be 8 characters or less\n");
+        ret = -9;
+        goto cleanup;
+      }
+
+      if (len > 0) {
+        for (size_t i = 0; i < len; i++) {
+          if (new_player_name[i] >= 'a' && new_player_name[i] <= 'z') {
+            new_player_name[i] = new_player_name[i] - 'a' + 'A';
+          } else if (!((new_player_name[i] >= 'A' && new_player_name[i] <= 'Z') || 
+                       (new_player_name[i] >= '0' && new_player_name[i] <= '9'))) {
+            fprintf(stderr, "Error: Player name must contain only letters (A-Z) and numbers (0-9)\n");
+            ret = -9;
+            goto cleanup;
+          }
+        }
+
+
+        strncpy(save->review.player_id, new_player_name, sizeof(save->review.player_id) - 1);
+        save->review.player_id[sizeof(save->review.player_id) - 1] = 0;
+        strncpy(save->stats.player_id, new_player_name, sizeof(save->stats.player_id) - 1);
+        save->stats.player_id[sizeof(save->stats.player_id) - 1] = 0;
+        
+
+        for (int i = 0; i < ASSET_NX2_USB_SAVE_SONG_MAX; i++) {
+          for (int j = 0; j < ASSET_NX2_USB_SAVE_NUM_MODES; j++) {
+
+            if (save->stats.song_scores[i][j].player_id[0] != '\0') {
+              strncpy(save->stats.song_scores[i][j].player_id, new_player_name, 
+                      sizeof(save->stats.song_scores[i][j].player_id) - 1);
+              save->stats.song_scores[i][j].player_id[sizeof(save->stats.song_scores[i][j].player_id) - 1] = 0;
+            }
+          }
+        }
+        
+        printf("Player name updated to: %s\n", save->review.player_id);
+      } else {
+        printf("Player name kept as: %s\n", save->review.player_id);
+      }
+
+      printf("Current profile picture: %d\n", save->stats.avatar_id);
+      printf("Enter new profile picture number (0-127, leave blank to keep current): ");
+      char pic_buf[16];
+      if (!fgets(pic_buf, sizeof(pic_buf), stdin)) {
+        fprintf(stderr, "Error: Failed to read input\n");
+        ret = -9;
+        goto cleanup;
+      }
+      
+      pic_buf[strcspn(pic_buf, "\n")] = 0;
+      
+      if (strlen(pic_buf) > 0) {
+        char *endp = NULL;
+        long pic_val = strtol(pic_buf, &endp, 10);
+        if (endp == pic_buf || *endp != '\0' || pic_val < 0 || pic_val > 127) {
+          fprintf(stderr, "Error: Picture number must be an integer between 0 and 127\n");
+          ret = -9;
+          goto cleanup;
+        }
+        
+        save->stats.avatar_id = (unsigned char)pic_val;
+        printf("Profile picture updated to: %ld\n", pic_val);
+      } else {
+        printf("Profile picture kept as: %d\n", save->stats.avatar_id);
+      }
+
+      printf("Current mileage: %d\n", save->stats.mileage);
+      printf("Enter new mileage (leave blank to keep current): ");
+      char mileage_buf[16];
+      if (!fgets(mileage_buf, sizeof(mileage_buf), stdin)) {
+        fprintf(stderr, "Error: Failed to read input\n");
+        ret = -9;
+        goto cleanup;
+      }
+      
+      mileage_buf[strcspn(mileage_buf, "\n")] = 0;
+      
+      if (strlen(mileage_buf) > 0) {
+        char *endp = NULL;
+        long mileage_val = strtol(mileage_buf, &endp, 10);
+        if (endp == mileage_buf || *endp != '\0' || mileage_val < 0 || mileage_val > INT32_MAX) {
+          fprintf(stderr, "Error: Mileage must be a positive integer\n");
+          ret = -9;
+          goto cleanup;
+        }
+        
+
+        int32_t old_mileage = save->stats.mileage;
+        save->review.mileage = (int32_t)mileage_val;
+        save->stats.mileage = (int32_t)mileage_val;
+        printf("Mileage updated from %d to %ld\n", old_mileage, mileage_val);
+      } else {
+        printf("Mileage kept as: %d\n", save->stats.mileage);
+      }
+
+      asset_nx2_usb_save_finalize(save);
+
+
+      if (!asset_nx2_usb_rank_save_to_file(rank_path_encrypted, rank, true)) {
+        fprintf(stderr, "Failed to save updated rank file %s\n", rank_path_encrypted);
+        ret = -6;
+      }
+
+      if (!asset_nx2_usb_save_save_to_file(save_path_encrypted, save, true)) {
+        fprintf(stderr, "Failed to save updated save file %s\n", save_path_encrypted);
+        ret = -7;
+      }
+
+      if (ret == 0) {
+        printf("Profile files updated successfully!\n");
+      }
+
+      ret = 0;
     } else {
-      fprintf(stderr, "Unknown command %s\n", argv[1]);
-      ret = -4;
+      printf("Unknown command. For usage: %s help\n", argv[0]);
+      
+      ret = 0;
     }
 
-    free(rank);
-    free(save);
-  }
-
 cleanup:
-  free(rank_path);
-  free(save_path);
+    if (rank) free(rank);
+    if (save) free(save);
+  
+  free(rank_path_encrypted);
+  free(save_path_encrypted);
+  free(rank_path_decrypted);
+  free(save_path_decrypted);
 
   return ret;
 }
+

--- a/src/main/capnhook/hooklib/redir.c
+++ b/src/main/capnhook/hooklib/redir.c
@@ -205,7 +205,7 @@ static enum cnh_result _cnh_redir_fshook_rename(struct cnh_fshook_irp *irp)
   _cnh_redir_init();
 
   res_old = _cnh_redir_check(irp->rename_old);
-  res_new = _cnh_redir_check(irp->rename_old);
+  res_new = _cnh_redir_check(irp->rename_new);
 
   if (res_old != NULL) {
     irp->rename_old = res_old;

--- a/src/main/capnhook/hooklib/usb-emu.c
+++ b/src/main/capnhook/hooklib/usb-emu.c
@@ -243,7 +243,7 @@ _cnh_usb_emu_usbhook_find_devices(struct cnh_usbhook_irp *irp)
         /* Append at end of bus chain */
         it->next = fakebus;
         /* Keep doubly linked list intact */
-        fakebus->prev = it->next;
+        fakebus->prev = it;
       }
 
       fakebus_dev_tail = NULL;

--- a/src/main/hook/mk3/main.c
+++ b/src/main/hook/mk3/main.c
@@ -22,6 +22,7 @@
 #include "hook/patch/sigsegv.h"
 #include "hook/patch/sound.h"
 #include "hook/patch/usb-emu.h"
+#include "hook/patch/usb-init-fix.h"
 
 #include "util/fs.h"
 #include "util/glibc.h"
@@ -195,6 +196,7 @@ static void mk3hook_patch_piuio_init(struct mk3hook_options *options)
     patch_piuio_exit_init();
   }
 
+  patch_usb_init_fix_init();
   patch_usb_emu_init();
 
   if (options->patch.piuio.api_lib) {

--- a/src/main/hook/nx2/options.c
+++ b/src/main/hook/nx2/options.c
@@ -240,11 +240,9 @@ bool nx2hook_options_init(
       options_opt, NX2HOOK_OPTIONS_STR_PATCH_HOOK_MAIN_LOOP_X11_INPUT_HANDLER);
   options->patch.net.server = util_options_get_str(
       options_opt, NX2HOOK_OPTIONS_STR_PATCH_NET_PROFILE_SERVER);
-  options->patch.net.machine_id = strtoull(
-      util_options_get_str(
-          options_opt, NX2HOOK_OPTIONS_STR_PATCH_NET_PROFILE_MACHINE_ID),
-      NULL,
-      16);
+  const char *machine_id_str = util_options_get_str(
+      options_opt, NX2HOOK_OPTIONS_STR_PATCH_NET_PROFILE_MACHINE_ID);
+  options->patch.net.machine_id = machine_id_str ? strtoull(machine_id_str, NULL, 16) : 0;
   options->patch.net.verbose_log_output = util_options_get_bool(
       options_opt, NX2HOOK_OPTIONS_STR_PATCH_NET_PROFILE_VERBOSE_LOG_OUTPUT);
   options->patch.net.cert_dir_path = util_options_get_str(

--- a/src/main/hook/nxa/options.c
+++ b/src/main/hook/nxa/options.c
@@ -238,11 +238,9 @@ bool nxahook_options_init(
       options_opt, NXAHOOK_OPTIONS_STR_PATCH_HOOK_MAIN_LOOP_X11_INPUT_HANDLER);
   options->patch.net.server = util_options_get_str(
       options_opt, NXAHOOK_OPTIONS_STR_PATCH_NET_PROFILE_SERVER);
-  options->patch.net.machine_id = strtoull(
-      util_options_get_str(
-          options_opt, NXAHOOK_OPTIONS_STR_PATCH_NET_PROFILE_MACHINE_ID),
-      NULL,
-      16);
+  const char *machine_id_str = util_options_get_str(
+      options_opt, NXAHOOK_OPTIONS_STR_PATCH_NET_PROFILE_MACHINE_ID);
+  options->patch.net.machine_id = machine_id_str ? strtoull(machine_id_str, NULL, 16) : 0;
   options->patch.net.verbose_log_output = util_options_get_bool(
       options_opt, NXAHOOK_OPTIONS_STR_PATCH_NET_PROFILE_VERBOSE_LOG_OUTPUT);
   options->patch.net.cert_dir_path = util_options_get_str(

--- a/src/main/hook/patch/asound-fix.c
+++ b/src/main/hook/patch/asound-fix.c
@@ -1,7 +1,11 @@
 #define LOG_MODULE "patch-asound-fix"
 
+#include <stdbool.h>
 #include <errno.h>
 #include <grp.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/types.h>
 
 #include "capnhook/hook/lib.h"
 
@@ -17,6 +21,64 @@ typedef int (*getgrnam_r_t)(
     struct group **result);
 
 static getgrnam_r_t patch_asound_fix_real_getgrnam_r;
+
+static char **patch_asound_fix_split_user_list_str(const char *user_list_str);
+
+static char *patch_asound_fix_dup_span(const char *start, size_t len)
+{
+  char *out = util_xmalloc(len + 1);
+
+  memcpy(out, start, len);
+  out[len] = '\0';
+
+  return out;
+}
+
+static bool patch_asound_fix_parse_group_line(
+    const char *line, struct group *grp)
+{
+  const char *c1 = strchr(line, ':');
+  const char *c2;
+  const char *c3;
+  const char *extra;
+  char *gid_end;
+  long gid;
+
+  if (c1 == NULL) {
+    return false;
+  }
+
+  c2 = strchr(c1 + 1, ':');
+
+  if (c2 == NULL) {
+    return false;
+  }
+
+  c3 = strchr(c2 + 1, ':');
+
+  if (c3 == NULL) {
+    return false;
+  }
+
+  extra = strchr(c3 + 1, ':');
+
+  if (extra != NULL) {
+    return false;
+  }
+
+  gid = strtol(c2 + 1, &gid_end, 10);
+
+  if (gid_end != c3 || gid < 0 || gid > UINT_MAX) {
+    return false;
+  }
+
+  grp->gr_name = patch_asound_fix_dup_span(line, c1 - line);
+  grp->gr_passwd = patch_asound_fix_dup_span(c1 + 1, c2 - (c1 + 1));
+  grp->gr_gid = (gid_t) gid;
+  grp->gr_mem = patch_asound_fix_split_user_list_str(c3 + 1);
+
+  return true;
+}
 
 static char **patch_asound_fix_split_user_list_str(const char *user_list_str)
 {
@@ -87,22 +149,48 @@ int getgrnam_r(
 
     FILE *file = fopen("/etc/group", "r");
 
+    if (file == NULL) {
+      log_error("Opening /etc/group failed: %s", strerror(errno));
+      *result = NULL;
+      return -1;
+    }
+
     fseek(file, 0, SEEK_END);
     size_t file_size = ftell(file);
     fseek(file, 0, SEEK_SET);
 
-    char *buffer = (char *) util_xmalloc(file_size);
+    char *buffer = (char *) util_xmalloc(file_size + 1);
 
     if (fread(buffer, file_size, 1, file) != 1) {
       log_error("Reading /etc/group file failed: %s", strerror(errno));
+      fclose(file);
       free(buffer);
       *result = NULL;
       return -1;
     }
 
-    char *str_audio_pos = strstr(buffer, name);
+    fclose(file);
+    buffer[file_size] = '\0';
 
-    if (str_audio_pos == NULL) {
+    char *line = buffer;
+    char *audio_line = NULL;
+
+    while (line != NULL && *line != '\0') {
+      char *next = strchr(line, '\n');
+
+      if (next != NULL) {
+        *next = '\0';
+      }
+
+      if (!strncmp(line, "audio:", strlen("audio:"))) {
+        audio_line = line;
+        break;
+      }
+
+      line = next ? next + 1 : NULL;
+    }
+
+    if (audio_line == NULL) {
       log_error(
           "Could not find 'audio' group in /etc/group required by libasound "
           "likely for defaults.pcm.ipc_gid"
@@ -112,38 +200,13 @@ int getgrnam_r(
       return -1;
     }
 
-    char *tok = strtok(str_audio_pos, ":");
-    uint8_t cnt = 0;
-
-    while (tok != NULL) {
-      switch (cnt) {
-        case 0:
-          grp->gr_name = util_str_dup(tok);
-          break;
-
-        case 1:
-          grp->gr_passwd = util_str_dup(tok);
-          break;
-
-        case 2:
-          grp->gr_gid = strtol(tok, NULL, 10);
-          break;
-
-        case 3:
-          grp->gr_mem = patch_asound_fix_split_user_list_str(tok);
-          break;
-
-        default:
-          log_error(
-              "audio group entry format in /etc/group invalid. Check your "
-              "/etc/group file!");
-          free(buffer);
-          *result = NULL;
-          return -1;
-      }
-
-      cnt++;
-      tok = strtok(NULL, ":");
+    if (!patch_asound_fix_parse_group_line(audio_line, grp)) {
+      log_error(
+          "audio group entry format in /etc/group invalid. Check your "
+          "/etc/group file!");
+      free(buffer);
+      *result = NULL;
+      return -1;
     }
 
     char *grp_mem_str = patch_asound_fix_user_list_to_str(grp->gr_mem);
@@ -154,6 +217,7 @@ int getgrnam_r(
         grp->gr_gid,
         grp_mem_str);
     free(grp_mem_str);
+    free(buffer);
 
     *result = grp;
 

--- a/src/main/hook/patch/hasp.c
+++ b/src/main/hook/patch/hasp.c
@@ -74,6 +74,8 @@ void patch_hasp_init(const uint8_t *key_data, size_t len)
   util_patch_function((uintptr_t) func_api_decrypt, sec_hasp_api_decrypt);
   util_patch_function((uintptr_t) func_api_getid, sec_hasp_api_getid);
 
+  util_patch_function(0x80dbd50, sec_hasp_api_get_sessioninfo);
+
   sec_hasp_init(key_data, len);
 
   log_info("Initialized");

--- a/src/main/hook/patch/piuio-exit.c
+++ b/src/main/hook/patch/piuio-exit.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 
 #include "capnhook/hook/usbhook.h"
 
@@ -65,7 +66,7 @@ static enum cnh_result patch_piuio_exit_usbhook(struct cnh_usbhook_irp *irp)
           if (((~irp->ctrl_buffer.bytes[1]) & (1 << 1)) &&
               ((~irp->ctrl_buffer.bytes[1]) & (1 << 6))) {
             log_info("Exit on service + test enabled and hit, bye");
-            exit(0);
+            _exit(0);
           }
         }
       }

--- a/src/main/hook/patch/piuio.c
+++ b/src/main/hook/patch/piuio.c
@@ -49,6 +49,11 @@ static uint32_t _patch_piuio_poll_delay_ms;
 static struct ptapi_io_piuio_api _patch_piuio_api;
 static enum ptapi_io_piuio_sensor_group _patch_piuio_sensor_group;
 
+// Improved input state management 
+static struct ptapi_io_piuio_pad_inputs _patch_piuio_pad_state[2][PTAPI_IO_PIUIO_SENSOR_GROUP_NUM];
+static struct ptapi_io_piuio_sys_inputs _patch_piuio_sys_state;
+static bool _patch_piuio_state_initialized = false;
+
 void patch_piuio_init(const char *piuio_lib_path, uint32_t poll_delay_ms)
 {
   _patch_piuio_poll_delay_ms = poll_delay_ms;
@@ -69,9 +74,14 @@ void patch_piuio_init(const char *piuio_lib_path, uint32_t poll_delay_ms)
     return;
   }
 
+  // Initialize all input state
+  memset(_patch_piuio_pad_state, 0, sizeof(_patch_piuio_pad_state));
+  memset(&_patch_piuio_sys_state, 0, sizeof(_patch_piuio_sys_state));
+  _patch_piuio_state_initialized = false;
+
   cnh_usb_emu_add_virtdevep(&_patch_piuio_virtdev);
 
-  log_info("Initialized");
+  log_info("Initialized with improved buffer handling");
 }
 
 void patch_piuio_shutdown(void)
@@ -98,6 +108,11 @@ static enum cnh_result _patch_piuio_open(void)
     return CNH_RESULT_OTHER_ERROR;
   }
 
+  // Reset state on device open
+  memset(_patch_piuio_pad_state, 0, sizeof(_patch_piuio_pad_state));
+  memset(&_patch_piuio_sys_state, 0, sizeof(_patch_piuio_sys_state));
+  _patch_piuio_state_initialized = false;
+
   return CNH_RESULT_SUCCESS;
 }
 
@@ -111,6 +126,11 @@ static enum cnh_result _patch_piuio_reset(void)
     log_error("Resetting api piuio %s failed", _patch_piuio_api.ident());
     return CNH_RESULT_OTHER_ERROR;
   }
+
+  // Clear all state on reset
+  memset(_patch_piuio_pad_state, 0, sizeof(_patch_piuio_pad_state));
+  memset(&_patch_piuio_sys_state, 0, sizeof(_patch_piuio_sys_state));
+  _patch_piuio_state_initialized = false;
 
   return CNH_RESULT_SUCCESS;
 }
@@ -228,101 +248,97 @@ static void _patch_piuio_read_inputs_to_buffer(struct cnh_iobuf *buffer)
   struct ptapi_io_piuio_pad_inputs p2_pad_in;
   struct ptapi_io_piuio_sys_inputs sys_in;
 
-  memset(&p1_pad_in, 0, sizeof(struct ptapi_io_piuio_pad_inputs));
-  memset(&p2_pad_in, 0, sizeof(struct ptapi_io_piuio_pad_inputs));
-  memset(&sys_in, 0, sizeof(struct ptapi_io_piuio_sys_inputs));
+  memset(&p1_pad_in, 0, sizeof(p1_pad_in));
+  memset(&p2_pad_in, 0, sizeof(p2_pad_in));
+  memset(&sys_in, 0, sizeof(sys_in));
 
+  // Read current inputs from API
   _patch_piuio_api.get_input_pad(0, _patch_piuio_sensor_group, &p1_pad_in);
   _patch_piuio_api.get_input_pad(1, _patch_piuio_sensor_group, &p2_pad_in);
-
   _patch_piuio_api.get_input_sys(&sys_in);
 
-  /*
-     byte 0:
-   bit 0: sensor p1: LU
-   bit 1: sensor p1: RU
-   bit 2: sensor p1: CN
-   bit 3: sensor p1: LD
-   bit 4: sensor p1: RD
-   bit 5:
-   bit 6:
-   bit 7:
-
-   byte 1:
-   bit 0:
-   bit 1: test
-   bit 2: coin 1
-   bit 3:
-   bit 4:
-   bit 5:
-   bit 6: service
-   bit 7: clear
-
-   byte 2:
-   bit 0: sensor p2: LU
-   bit 1: sensor p2: RU
-   bit 2: sensor p2: CN
-   bit 3: sensor p2: LD
-   bit 4: sensor p2: RD
-   bit 5:
-   bit 6:
-   bit 7:
-
-   byte 3:
-   bit 0:
-   bit 1:
-   bit 2: coin 2
-   bit 3:
-   bit 4:
-   bit 5:
-   bit 6:
-   bit 7:
-
-   bytes 4 - 7 dummy
-  */
-
-  /* Player 1 */
-  buffer->bytes[0] = 0;
-
-  buffer->bytes[0] |= ((p1_pad_in.lu ? 1 : 0) << 0);
-  buffer->bytes[0] |= ((p1_pad_in.ru ? 1 : 0) << 1);
-  buffer->bytes[0] |= ((p1_pad_in.cn ? 1 : 0) << 2);
-  buffer->bytes[0] |= ((p1_pad_in.ld ? 1 : 0) << 3);
-  buffer->bytes[0] |= ((p1_pad_in.rd ? 1 : 0) << 4);
-
-  buffer->bytes[0] ^= 0xFF;
-
-  /* Player 2 */
-  buffer->bytes[2] = 0;
-
-  buffer->bytes[2] |= ((p2_pad_in.lu ? 1 : 0) << 0);
-  buffer->bytes[2] |= ((p2_pad_in.ru ? 1 : 0) << 1);
-  buffer->bytes[2] |= ((p2_pad_in.cn ? 1 : 0) << 2);
-  buffer->bytes[2] |= ((p2_pad_in.ld ? 1 : 0) << 3);
-  buffer->bytes[2] |= ((p2_pad_in.rd ? 1 : 0) << 4);
-
-  buffer->bytes[2] ^= 0xFF;
-
-  /* Sys */
-  buffer->bytes[1] = 0;
-
-  buffer->bytes[1] |= ((sys_in.test ? 1 : 0) << 1);
-  buffer->bytes[1] |= ((sys_in.service ? 1 : 0) << 6);
-  buffer->bytes[1] |= ((sys_in.clear ? 1 : 0) << 7);
-  buffer->bytes[1] |= ((sys_in.coin ? 1 : 0) << 2);
-
-  buffer->bytes[1] ^= 0xFF;
-
-  /* Apparently, "touching" byte 3 as a whole causes some random and weird input
-     triggering which results in the service menu popping up. Don't clear the
-     whole byte, touch coin2 only to avoid this */
-  if (!sys_in.coin2) {
-    buffer->bytes[3] |= (1 << 2);
-  } else {
-    buffer->bytes[3] &= ~(1 << 2);
+  // Initialize state on first call
+  if (!_patch_piuio_state_initialized) {
+    _patch_piuio_pad_state[0][_patch_piuio_sensor_group] = p1_pad_in;
+    _patch_piuio_pad_state[1][_patch_piuio_sensor_group] = p2_pad_in;
+    _patch_piuio_sys_state = sys_in;
+    _patch_piuio_state_initialized = true;
   }
 
+  // Initialize buffer with all bits set (PIUIO uses inverted logic)
+  memset(buffer->bytes, 0xFF, PIUIO_DRV_BUFFER_SIZE);
+
+  /*
+     PIUIO Protocol Format (inverted logic - 0 = pressed, 1 = not pressed):
+     
+     byte 0: Player 1 pad sensors
+     bit 0: sensor p1: LU (left-up)
+     bit 1: sensor p1: RU (right-up) 
+     bit 2: sensor p1: CN (center)
+     bit 3: sensor p1: LD (left-down)
+     bit 4: sensor p1: RD (right-down)
+     bits 5-7: unused
+
+     byte 1: System controls
+     bit 1: test button
+     bit 2: coin 1
+     bit 6: service button  
+     bit 7: clear button
+     other bits: unused
+
+     byte 2: Player 2 pad sensors
+     bit 0: sensor p2: LU
+     bit 1: sensor p2: RU
+     bit 2: sensor p2: CN
+     bit 3: sensor p2: LD
+     bit 4: sensor p2: RD
+     bits 5-7: unused
+
+     byte 3: Additional system inputs
+     bit 2: coin 2
+     other bits: unused
+
+     bytes 4-7: unused
+  */
+
+  // Player 1 inputs - clear bits for pressed buttons
+  if (p1_pad_in.lu) buffer->bytes[0] &= ~(1 << 0);
+  if (p1_pad_in.ru) buffer->bytes[0] &= ~(1 << 1);
+  if (p1_pad_in.cn) buffer->bytes[0] &= ~(1 << 2);
+  if (p1_pad_in.ld) buffer->bytes[0] &= ~(1 << 3);
+  if (p1_pad_in.rd) buffer->bytes[0] &= ~(1 << 4);
+
+  // Player 2 inputs - clear bits for pressed buttons
+  if (p2_pad_in.lu) buffer->bytes[2] &= ~(1 << 0);
+  if (p2_pad_in.ru) buffer->bytes[2] &= ~(1 << 1);
+  if (p2_pad_in.cn) buffer->bytes[2] &= ~(1 << 2);
+  if (p2_pad_in.ld) buffer->bytes[2] &= ~(1 << 3);
+  if (p2_pad_in.rd) buffer->bytes[2] &= ~(1 << 4);
+
+  // System inputs - clear bits for pressed buttons
+  if (sys_in.test) buffer->bytes[1] &= ~(1 << 1);
+  if (sys_in.service) buffer->bytes[1] &= ~(1 << 6);
+  if (sys_in.clear) buffer->bytes[1] &= ~(1 << 7);
+  if (sys_in.coin) buffer->bytes[1] &= ~(1 << 2);
+
+  // Coin 2 - handle carefully to prevent false service menu triggers
+  if (sys_in.coin2) {
+    buffer->bytes[3] &= ~(1 << 2);
+  }
+  // Note: Other bits in byte 3 remain set to 1 to prevent false triggers
+
+  // Update state for next cycle
+  _patch_piuio_pad_state[0][_patch_piuio_sensor_group] = p1_pad_in;
+  _patch_piuio_pad_state[1][_patch_piuio_sensor_group] = p2_pad_in;
+  _patch_piuio_sys_state = sys_in;
+
   buffer->pos = PIUIO_DRV_BUFFER_SIZE;
+
+#ifdef PATCH_PIUIO_CALL_TRACE
+  log_debug("Input buffer: %02X %02X %02X %02X %02X %02X %02X %02X", 
+            buffer->bytes[0], buffer->bytes[1], buffer->bytes[2], buffer->bytes[3],
+            buffer->bytes[4], buffer->bytes[5], buffer->bytes[6], buffer->bytes[7]);
+#endif
 }
 
 static void _patch_piuio_read_outputs_from_buffer(struct cnh_iobuf *buffer)
@@ -332,29 +348,21 @@ static void _patch_piuio_read_outputs_from_buffer(struct cnh_iobuf *buffer)
   struct ptapi_io_piuio_cab_outputs cab_out;
 
   /*
+   PIUIO Output Format:
+   
    byte 0:
-   bit 0: sensor id bit 0	select sensor to be read for next input request:
-   bit 1: sensor id bit 1   00 = sens1, 01 = sens2, 10 = sens3, 11 = sens4
+   bit 0-1: sensor id (00=right, 01=left, 10=down, 11=up)
    bit 2: pad light p1: LU
    bit 3: pad light p1: RU
    bit 4: pad light p1: CN
    bit 5: pad light p1: LD
    bit 6: pad light p1: RD
-   bit 7:
 
    byte 1:
-   bit 0:
-   bit 1:
-   bit 2: light neons
-   bit 3: coin counter 2 (front usb ports enable)
-   bit 4:
-   bit 5:
-   bit 6:
-   bit 7:
+   bit 2: bass/neon lights
+   bit 3: coin counter 2 (front USB enable)
 
    byte 2:
-   bit 0:
-   bit 1:
    bit 2: pad light p2: LU
    bit 3: pad light p2: RU
    bit 4: pad light p2: CN
@@ -366,36 +374,47 @@ static void _patch_piuio_read_outputs_from_buffer(struct cnh_iobuf *buffer)
    bit 0: halogen R1
    bit 1: halogen L2
    bit 2: halogen L1
-   bit 3:
    bit 4: coin counter 1
-   bit 5:
-   bit 6:
-   bit 7:
 
-   bytes 4 - 7 dummy
+   bytes 4-7: unused
   */
 
-  p1_pad_out.lu = (buffer->bytes[0] & (1 << 2)) > 0;
-  p1_pad_out.ru = (buffer->bytes[0] & (1 << 3)) > 0;
-  p1_pad_out.cn = (buffer->bytes[0] & (1 << 4)) > 0;
-  p1_pad_out.ld = (buffer->bytes[0] & (1 << 5)) > 0;
-  p1_pad_out.rd = (buffer->bytes[0] & (1 << 6)) > 0;
+  memset(&p1_pad_out, 0, sizeof(p1_pad_out));
+  memset(&p2_pad_out, 0, sizeof(p2_pad_out));
+  memset(&cab_out, 0, sizeof(cab_out));
 
-  p2_pad_out.lu = (buffer->bytes[2] & (1 << 2)) > 0;
-  p2_pad_out.ru = (buffer->bytes[2] & (1 << 3)) > 0;
-  p2_pad_out.cn = (buffer->bytes[2] & (1 << 4)) > 0;
-  p2_pad_out.ld = (buffer->bytes[2] & (1 << 5)) > 0;
-  p2_pad_out.rd = (buffer->bytes[2] & (1 << 6)) > 0;
+  // Player 1 pad lights
+  p1_pad_out.lu = (buffer->bytes[0] & (1 << 2)) != 0;
+  p1_pad_out.ru = (buffer->bytes[0] & (1 << 3)) != 0;
+  p1_pad_out.cn = (buffer->bytes[0] & (1 << 4)) != 0;
+  p1_pad_out.ld = (buffer->bytes[0] & (1 << 5)) != 0;
+  p1_pad_out.rd = (buffer->bytes[0] & (1 << 6)) != 0;
 
-  cab_out.bass = (buffer->bytes[1] & (1 << 2)) > 0;
-  cab_out.halo_r2 = (buffer->bytes[2] & (1 << 7)) > 0;
-  cab_out.halo_r1 = (buffer->bytes[3] & (1 << 0)) > 0;
-  cab_out.halo_l2 = (buffer->bytes[3] & (1 << 1)) > 0;
-  cab_out.halo_l1 = (buffer->bytes[3] & (1 << 2)) > 0;
+  // Player 2 pad lights
+  p2_pad_out.lu = (buffer->bytes[2] & (1 << 2)) != 0;
+  p2_pad_out.ru = (buffer->bytes[2] & (1 << 3)) != 0;
+  p2_pad_out.cn = (buffer->bytes[2] & (1 << 4)) != 0;
+  p2_pad_out.ld = (buffer->bytes[2] & (1 << 5)) != 0;
+  p2_pad_out.rd = (buffer->bytes[2] & (1 << 6)) != 0;
 
+  // Cabinet lights
+  cab_out.bass = (buffer->bytes[1] & (1 << 2)) != 0;
+  cab_out.halo_r2 = (buffer->bytes[2] & (1 << 7)) != 0;
+  cab_out.halo_r1 = (buffer->bytes[3] & (1 << 0)) != 0;
+  cab_out.halo_l2 = (buffer->bytes[3] & (1 << 1)) != 0;
+  cab_out.halo_l1 = (buffer->bytes[3] & (1 << 2)) != 0;
+
+  // Send outputs to API
   _patch_piuio_api.set_output_pad(0, &p1_pad_out);
   _patch_piuio_api.set_output_pad(1, &p2_pad_out);
   _patch_piuio_api.set_output_cab(&cab_out);
+
+#ifdef PATCH_PIUIO_CALL_TRACE
+  log_debug("Output: P1[%d%d%d%d%d] P2[%d%d%d%d%d] Cab[%d%d%d%d%d]",
+            p1_pad_out.lu, p1_pad_out.ru, p1_pad_out.cn, p1_pad_out.ld, p1_pad_out.rd,
+            p2_pad_out.lu, p2_pad_out.ru, p2_pad_out.cn, p2_pad_out.ld, p2_pad_out.rd,
+            cab_out.bass, cab_out.halo_r1, cab_out.halo_r2, cab_out.halo_l1, cab_out.halo_l2);
+#endif
 }
 
 static enum ptapi_io_piuio_sensor_group

--- a/src/main/hook/pro2/main.c
+++ b/src/main/hook/pro2/main.c
@@ -19,6 +19,8 @@
 #include "hook/patch/usb-init-fix.h"
 #include "hook/patch/x11-event-loop.h"
 
+#include "hook/propatch/usb-fix.h"
+
 #include "hook/patch/piubtn.h"
 #include "hook/patch/piuio.h"
 
@@ -160,6 +162,14 @@ static void pro2hook_patch_x11_event_loop_init(struct pro2hook_options *options)
   }
 }
 
+static void pro2hook_patch_usbprofiles(struct pro2hook_options *options)
+{
+  propatch_usb_fix_init(
+      options->patch.usb_profile.device_nodes,
+      options->patch.usb_profile.p1_bus_port,
+      options->patch.usb_profile.p2_bus_port);
+}
+
 static void pro2hook_patch_piuio_init(struct pro2hook_options *options)
 {
   log_assert(options);
@@ -236,6 +246,7 @@ void pro2hook_trap_before_main(int argc, char **argv)
   pro2hook_fs_redirs_init(&options);
   pro2hook_patch_sigsegv_init(&options);
   pro2hook_patch_x11_event_loop_init(&options);
+  pro2hook_patch_usbprofiles(&options);
   pro2hook_patch_piuio_init(&options);
   pro2hook_patch_piubtn_init(&options);
   pro2hook_patch_secure_binary();
@@ -245,6 +256,7 @@ void pro2hook_trap_before_main(int argc, char **argv)
 
 void pro2hook_trap_after_main(void)
 {
+  propatch_usb_fix_shutdown();
   patch_piubtn_shutdown();
   patch_piuio_shutdown();
 }

--- a/src/main/hook/pro2/options.c
+++ b/src/main/hook/pro2/options.c
@@ -12,6 +12,12 @@
 #define PRO2HOOK_OPTIONS_STR_PATCH_PIUIO_EMU_LIB "patch.piuio.emu_lib"
 #define PRO2HOOK_OPTIONS_STR_PATCH_PIUIO_EXIT_TEST_SERV \
   "patch.piuio_exit.test_serv"
+#define PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P1_BUS_PORT \
+    "patch.usb_profile.p1.bus_port"
+#define PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P2_BUS_PORT \
+    "patch.usb_profile.p2.bus_port"
+#define PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_DEV_NODES \
+    "patch.usb_profile.dev_nodes"
 #define PRO2HOOK_OPTIONS_STR_PATCH_X11_EVENT_LOOP_INPUT_HANDLER \
   "patch_x11_event_loop.input_handler_lib"
 #define PRO2HOOK_OPTIONS_STR_PATCH_X11_EVENT_LOOP_INPUT_HANDLER2 \
@@ -95,6 +101,36 @@ const struct util_options_def pro2hook_options_def[] = {
         .default_value.b = false,
     },
     {
+        .name = PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P1_BUS_PORT,
+        .description = "Bus and port (format: X-X, e.g. 1-2) of the USB slot "
+                       "to assign to Player 1 when a USB thumb "
+                       "drive is plugged in",
+        .param = 'a',
+        .type = UTIL_OPTIONS_TYPE_STR,
+        .is_secret_data = false,
+        .default_value.str = NULL,
+    },
+    {
+        .name = PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P2_BUS_PORT,
+        .description = "Bus and port (format: X-X, e.g. 1-2) of the USB slot "
+                       "to assign to Player 2 when a USB thumb "
+                       "drive is plugged in",
+        .param = 'k',
+        .type = UTIL_OPTIONS_TYPE_STR,
+        .is_secret_data = false,
+        .default_value.str = NULL,
+    },
+    {
+        .name = PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_DEV_NODES,
+        .description = "Device nodes of plugged in USB thumb drives to "
+                       "consider for mounting for usb profiles, format: "
+                       "sdX,sdY e.g. sde,sdf",
+        .param = 't',
+        .type = UTIL_OPTIONS_TYPE_STR,
+        .is_secret_data = false,
+        .default_value.str = NULL,
+    },
+    {
         .name = PRO2HOOK_OPTIONS_STR_PATCH_X11_EVENT_LOOP_INPUT_HANDLER,
         .description = "Path to a library implementing the x11-input-handler "
                        "api to capture X11 keyboard inputs",
@@ -172,6 +208,12 @@ bool pro2hook_options_init(
       options_opt, PRO2HOOK_OPTIONS_STR_PATCH_PIUIO_EMU_LIB);
   options->patch.piuio.exit_test_serv = util_options_get_bool(
       options_opt, PRO2HOOK_OPTIONS_STR_PATCH_PIUIO_EXIT_TEST_SERV);
+  options->patch.usb_profile.device_nodes = util_options_get_str(
+      options_opt, PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_DEV_NODES);
+  options->patch.usb_profile.p1_bus_port = util_options_get_str(
+      options_opt, PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P1_BUS_PORT);
+  options->patch.usb_profile.p2_bus_port = util_options_get_str(
+      options_opt, PRO2HOOK_OPTIONS_STR_PATCH_USB_PROFILE_P2_BUS_PORT);
   options->patch.x11_event_loop.api_lib = util_options_get_str(
       options_opt, PRO2HOOK_OPTIONS_STR_PATCH_X11_EVENT_LOOP_INPUT_HANDLER);
   options->patch.x11_event_loop.api_lib2 = util_options_get_str(

--- a/src/main/hook/pro2/options.h
+++ b/src/main/hook/pro2/options.h
@@ -29,6 +29,12 @@ struct pro2hook_options {
       bool exit_test_serv;
     } piuio;
 
+    struct usb_profile {
+      const char *device_nodes;
+      const char *p1_bus_port;
+      const char *p2_bus_port;
+    } usb_profile;
+
     struct x11_event_loop {
       const char *api_lib;
       const char *api_lib2;

--- a/src/main/hook/propatch/usb-fix.c
+++ b/src/main/hook/propatch/usb-fix.c
@@ -1,5 +1,6 @@
 #define LOG_MODULE "usb-fix"
 
+#include <ctype.h>
 #include <unistd.h>
 
 #include "capnhook/hook/lib.h"
@@ -69,9 +70,12 @@ ssize_t propatch_usb_fix_readlink(const char *path, char *buf, size_t len)
 
       toks = util_str_split(buf, "/", &count);
 
+      log_debug("Parsing USB device path with %zu tokens", count);
+
       // some sanity checks to ensure the format isn't different
-      if (count != 12 || strcmp(toks[0], "..") != 0 ||
-          strcmp(toks[1], "devices") != 0 || strcmp(toks[10], "block") != 0) {
+      // The format can vary between 12 and 13 tokens depending on USB hierarchy depth
+      if (count < 12 || count > 13 || strcmp(toks[0], "..") != 0 ||
+          strcmp(toks[1], "devices") != 0 || strcmp(toks[count-2], "block") != 0) {
         log_error(
             "/sys/block device readlink format changed, usb thumb drive "
             "profiles will likely not work!: %s",
@@ -82,10 +86,26 @@ ssize_t propatch_usb_fix_readlink(const char *path, char *buf, size_t len)
 
       int bus;
       int port;
-      const char *device = toks[11];
+      const char *device = toks[count-1];
 
-      if (sscanf(toks[5], "%d-%d", &bus, &port) != 2) {
-        log_error("Parsing bus-port of %s failed", buf);
+      // Find the USB device identifier token (format: X-Y or X-Y.Z or X-Y.Z.W etc.)
+      // It should be one of the tokens that starts with a digit and contains a dash
+      bool found_usb_id = false;
+      for (size_t i = 4; i < count - 3; i++) {  // Skip initial path components and final ones
+        if (isdigit(toks[i][0]) && strchr(toks[i], '-')) {
+          log_debug("Checking USB identifier token[%zu]: %s", i, toks[i]);
+          // Try to parse the main bus-port from this token
+          char *dash_pos = strchr(toks[i], '-');
+          if (dash_pos && sscanf(toks[i], "%d-%d", &bus, &port) == 2) {
+            log_debug("Successfully parsed USB bus %d, port %d from token: %s", bus, port, toks[i]);
+            found_usb_id = true;
+            break;
+          }
+        }
+      }
+      
+      if (!found_usb_id) {
+        log_error("Could not find valid USB bus-port identifier in path: %s", buf);
         util_str_free_split(toks, count);
         return 0;
       }

--- a/src/main/io/lxio/defs.h
+++ b/src/main/io/lxio/defs.h
@@ -2,7 +2,8 @@
 #define LXIO_DRV_DEFS_H
 
 #define LXIO_VID 0x0D2F
-#define LXIO_PID 0x1020
+static const int LXIO_PID[] = { 0x1040, 0x1020 };
+#define LXIO_PID_COUNT  (sizeof(LXIO_PID) / sizeof(LXIO_PID[0]))
 
 #define LXIO_DRV_USB_REQ_TIMEOUT 10000
 

--- a/src/main/io/lxio/device.c
+++ b/src/main/io/lxio/device.c
@@ -16,7 +16,12 @@ bool lxio_drv_device_open(void)
     return true;
   }
 
-  lxio_drv_device_handle = io_usb_open(LXIO_VID, LXIO_PID, 1, 0);
+  for( int p = 0; p < LXIO_PID_COUNT; ++p ) {
+    lxio_drv_device_handle = io_usb_open(LXIO_VID, LXIO_PID[p], 1, 0);
+    if( lxio_drv_device_handle ) {
+      break;
+    }
+  }
 
   return lxio_drv_device_handle;
 }

--- a/src/main/ptapi/io/piubtn/joystick/joystick.c
+++ b/src/main/ptapi/io/piubtn/joystick/joystick.c
@@ -60,6 +60,21 @@ bool ptapi_io_piubtn_open()
   struct io_util_joystick_util_device_info device_info[MAX_NUM_JOYSTICKS];
   size_t devices_connected;
 
+  if (util_proc_get_folder_path_shared_object(
+          (void *) ptapi_io_piubtn_open, path, sizeof(path))) {
+    config_path = util_str_merge(path, CONFIG_FILENAME);
+
+    log_info("Loading configuration from emu lib path: %s", config_path);
+
+    if (ptapi_io_piubtn_joystick_util_conf_read_from_file(
+            &ptapi_io_piubtn_joystick_util_conf, config_path)) {
+      free(config_path);
+      goto conf_loaded;
+    }
+
+    free(config_path);
+  }
+
   // The game changes the working directory to the 'game' sub-folder. Therefore,
   // ./my-config does not work here.
   if (!util_proc_get_folder_path_executable_no_ld_linux(path, sizeof(path))) {
@@ -69,6 +84,8 @@ bool ptapi_io_piubtn_open()
 
   config_path = util_str_merge(path, CONFIG_FILENAME);
 
+  log_info("Loading configuration from executable path: %s", config_path);
+
   if (!ptapi_io_piubtn_joystick_util_conf_read_from_file(
           &ptapi_io_piubtn_joystick_util_conf, config_path)) {
     log_error("Loading joystick config file %s failed.", CONFIG_FILENAME);
@@ -77,6 +94,8 @@ bool ptapi_io_piubtn_open()
   }
 
   free(config_path);
+
+conf_loaded:
 
   devices_connected =
       io_util_joystick_util_scan(device_info, MAX_NUM_JOYSTICKS);

--- a/src/main/ptapi/io/piubtn/keyboard/keyboard.c
+++ b/src/main/ptapi/io/piubtn/keyboard/keyboard.c
@@ -48,6 +48,22 @@ bool ptapi_io_piubtn_open()
   char path[PATH_MAX];
   char *config_path;
 
+  if (util_proc_get_folder_path_shared_object(
+          (void *) ptapi_io_piubtn_open, path, sizeof(path))) {
+    config_path = util_str_merge(path, CONFIG_FILENAME);
+
+    log_info("Loading configuration from emu lib path: %s", config_path);
+
+    if (ptapi_io_piubtn_keyboard_util_conf_read_from_file(
+            &ptapi_io_piubtn_keyboard_conf, config_path)) {
+      free(config_path);
+      memset(ptapi_io_piubtn_keyboard_buffer, 0, sizeof(bool) * KEY_MAP_SIZE);
+      return true;
+    }
+
+    free(config_path);
+  }
+
   // The game changes the working directory to the 'game' sub-folder. Therefore,
   // ./my-config does not work here.
   if (!util_proc_get_folder_path_executable_no_ld_linux(path, sizeof(path))) {
@@ -56,6 +72,8 @@ bool ptapi_io_piubtn_open()
   }
 
   config_path = util_str_merge(path, CONFIG_FILENAME);
+
+  log_info("Loading configuration from executable path: %s", config_path);
 
   if (!ptapi_io_piubtn_keyboard_util_conf_read_from_file(
           &ptapi_io_piubtn_keyboard_conf, config_path)) {

--- a/src/main/ptapi/io/piuio/joystick/joystick.c
+++ b/src/main/ptapi/io/piuio/joystick/joystick.c
@@ -60,6 +60,21 @@ bool ptapi_io_piuio_open()
   struct io_util_joystick_util_device_info device_info[MAX_NUM_JOYSTICKS];
   size_t devices_connected;
 
+  if (util_proc_get_folder_path_shared_object(
+          (void *) ptapi_io_piuio_open, path, sizeof(path))) {
+    config_path = util_str_merge(path, CONFIG_FILENAME);
+
+    log_info("Loading configuration from emu lib path: %s", config_path);
+
+    if (ptapi_io_piuio_joystick_util_conf_read_from_file(
+            &ptapi_io_piuio_joystick_util_conf, config_path)) {
+      free(config_path);
+      goto conf_loaded;
+    }
+
+    free(config_path);
+  }
+
   // The game changes the working directory to the 'game' sub-folder. Therefore,
   // ./my-config does not work here.
   if (!util_proc_get_folder_path_executable_no_ld_linux(path, sizeof(path))) {
@@ -69,7 +84,7 @@ bool ptapi_io_piuio_open()
 
   config_path = util_str_merge(path, CONFIG_FILENAME);
 
-  log_info("Loading configuration: ", config_path);
+  log_info("Loading configuration from executable path: %s", config_path);
 
   if (!ptapi_io_piuio_joystick_util_conf_read_from_file(
           &ptapi_io_piuio_joystick_util_conf, config_path)) {
@@ -79,6 +94,8 @@ bool ptapi_io_piuio_open()
   }
 
   free(config_path);
+
+conf_loaded:
 
   devices_connected =
       io_util_joystick_util_scan(device_info, MAX_NUM_JOYSTICKS);

--- a/src/main/ptapi/io/piuio/keyboard/keyboard.c
+++ b/src/main/ptapi/io/piuio/keyboard/keyboard.c
@@ -47,6 +47,22 @@ bool ptapi_io_piuio_open()
   char path[PATH_MAX];
   char *config_path;
 
+  if (util_proc_get_folder_path_shared_object(
+          (void *) ptapi_io_piuio_open, path, sizeof(path))) {
+    config_path = util_str_merge(path, CONFIG_FILENAME);
+
+    log_info("Loading configuration from emu lib path: %s", config_path);
+
+    if (ptapi_io_piuio_keyboard_util_conf_read_from_file(
+            &ptapi_io_piuio_keyboard_conf, config_path)) {
+      free(config_path);
+      memset(ptapi_io_piuio_keyboard_buffer, 0, sizeof(bool) * KEY_MAP_SIZE);
+      return true;
+    }
+
+    free(config_path);
+  }
+
   // The game changes the working directory to the 'game' sub-folder. Therefore,
   // ./my-config does not work here.
   if (!util_proc_get_folder_path_executable_no_ld_linux(path, sizeof(path))) {
@@ -56,7 +72,7 @@ bool ptapi_io_piuio_open()
 
   config_path = util_str_merge(path, CONFIG_FILENAME);
 
-  log_info("Loading configuration: ", config_path);
+  log_info("Loading configuration from executable path: %s", config_path);
 
   if (!ptapi_io_piuio_keyboard_util_conf_read_from_file(
           &ptapi_io_piuio_keyboard_conf, config_path)) {

--- a/src/main/ptapi/io/piuio/lxio/lxio.c
+++ b/src/main/ptapi/io/piuio/lxio/lxio.c
@@ -79,6 +79,11 @@ void convert_output_to_lxio()
     lxio_light_state_buffer[1] |= (1 << 2);
   }
 
+  /* enable usb inhibitor and coins, always on */
+  lxio_light_state_buffer[3] |= (1 << 4);
+  lxio_light_state_buffer[3] |= (1 << 5);
+  lxio_light_state_buffer[3] |= (1 << 6);
+
   /* Halogens */
 
   if (ptapi_piuio_cab_out.halo_r1) {

--- a/src/main/ptapi/io/piuio/lxio/lxio.c
+++ b/src/main/ptapi/io/piuio/lxio/lxio.c
@@ -79,10 +79,15 @@ void convert_output_to_lxio()
     lxio_light_state_buffer[1] |= (1 << 2);
   }
 
+  /* coin counter 1 */
+  if(ptapi_piuio_sys.coin) {
+    lxio_light_state_buffer[3] |= (1 << 3);
+  }
+
   /* enable usb inhibitor and coins, always on */
-  lxio_light_state_buffer[3] |= (1 << 4);
-  lxio_light_state_buffer[3] |= (1 << 5);
-  lxio_light_state_buffer[3] |= (1 << 6);
+  lxio_light_state_buffer[3] |= (1 << 4); // usb enable
+  lxio_light_state_buffer[3] |= (1 << 5); // coin1
+  lxio_light_state_buffer[3] |= (1 << 6); // coin2
 
   /* Halogens */
 

--- a/src/main/sec/hasp/old/hasp.c
+++ b/src/main/sec/hasp/old/hasp.c
@@ -95,3 +95,14 @@ int sec_hasp_api_decrypt(int handle, void *buffer, size_t length)
 
   return 0;
 }
+
+int sec_hasp_api_get_sessioninfo(int handle, const char *format, const char **info)
+{
+  static const char dummy_info[] = "p ";
+
+  if (info) {
+    *info = dummy_info;
+  }
+
+  return 0;
+}

--- a/src/main/sec/hasp/old/hasp.h
+++ b/src/main/sec/hasp/old/hasp.h
@@ -32,4 +32,6 @@ unsigned int sec_hasp_api_getid(void);
 
 int sec_hasp_api_decrypt(int handle, void *buffer, size_t length);
 
+int sec_hasp_api_get_sessioninfo(int handle, const char *format, const char **info);
+
 #endif

--- a/src/main/util/fs.c
+++ b/src/main/util/fs.c
@@ -210,15 +210,39 @@ char *util_fs_get_filename(const char *path)
 
 char *util_fs_get_abs_path(const char *path)
 {
+  size_t path_len;
   char *real_path;
+
+  if (!path) {
+    return NULL;
+  }
+
+  path_len = strlen(path);
+
+  if (path_len == 0) {
+    real_path = (char *) util_xmalloc(1);
+    real_path[0] = '\0';
+    return real_path;
+  }
+
+  /* Keep explicit absolute paths untouched to support external mount points. */
+  if (path[0] == '/') {
+    real_path = (char *) util_xmalloc(path_len + 1);
+    memcpy(real_path, path, path_len + 1);
+    return real_path;
+  }
 
   real_path = realpath(path, NULL);
 
   if (!real_path) {
-    log_error(
+    log_warn(
         "Resolving path '%s' to absolute path failed: %s",
         path,
         strerror(errno));
+
+    /* Fall back to the original path and let the dynamic loader resolve it. */
+    real_path = (char *) util_xmalloc(path_len + 1);
+    memcpy(real_path, path, path_len + 1);
   }
 
   return real_path;

--- a/src/main/util/proc.c
+++ b/src/main/util/proc.c
@@ -1,5 +1,6 @@
 #define LOG_MODULE "util-proc"
 
+#include <dlfcn.h>
 #include <errno.h>
 #include <linux/limits.h>
 #include <string.h>
@@ -203,6 +204,40 @@ bool util_proc_get_folder_path_executable_no_ld_linux(char *buffer, size_t size)
   } else {
     return util_proc_get_folder_path_executable(buffer, size);
   }
+}
+
+bool util_proc_get_folder_path_shared_object(
+    void *symbol, char *buffer, size_t size)
+{
+  Dl_info info;
+
+  if (!symbol || !buffer || size == 0) {
+    return false;
+  }
+
+  if (!dladdr(symbol, &info) || !info.dli_fname) {
+    return false;
+  }
+
+  if (strlen(info.dli_fname) >= size) {
+    return false;
+  }
+
+  strcpy(buffer, info.dli_fname);
+
+  // If shared object in the root folder, keep the single /
+  size_t pos = strlen(buffer) - 1;
+  while (pos > 0 && buffer[pos] != '/') {
+    buffer[pos] = '\0';
+    pos--;
+  }
+
+  // delete /
+  if (pos > 0) {
+    buffer[pos] = '\0';
+  }
+
+  return true;
 }
 
 void util_proc_log_info()

--- a/src/main/util/proc.h
+++ b/src/main/util/proc.h
@@ -44,6 +44,18 @@ bool util_proc_get_folder_path_executable_no_ld_linux(
     char *buffer, size_t size);
 
 /**
+ * Get the full path of the folder of the shared object that contains the
+ * supplied symbol.
+ *
+ * @param symbol Pointer to any symbol in the target shared object.
+ * @param buffer Buffer to read the path into.
+ * @param size Size of the buffer.
+ * @return True on success, false on failure.
+ */
+bool util_proc_get_folder_path_shared_object(
+    void *symbol, char *buffer, size_t size);
+
+/**
  * Log information about the current process to the console.
  */
 void util_proc_log_info();


### PR DESCRIPTION
I was trying to do something else and found out that USB profiles on Fiesta 2 don't work, when you introduce empty drive or a drive with valid fiesta2 profile on it, the game will just freeze on the title screen and spam the log with HASP login/out attempts roughly 10 times per frame.

I was sent a patched hook.so that has been manually edited, reverse engineered the short function and implemented it here in this pull request.

Needs to be tested on arcade still.