### PR TITLE
Fiesta2 usb profile fix

### DIFF
--- a/src/main/hook/f2/main.c
+++ b/src/main/hook/f2/main.c
@@ -181,7 +181,8 @@ static void f2hook_patch_dongle_init()
   patch_hasp_init(
       (const uint8_t *) _binary_f2hook_hasp_key_start,
       ((uintptr_t) &_binary_f2hook_hasp_key_end -
-       (uintptr_t) &_binary_f2hook_hasp_key_start));
+       (uintptr_t) &_binary_f2hook_hasp_key_start),
+      0x80dbd50);
 }
 
 static void f2hook_patch_hdd_check_init()

--- a/src/main/hook/patch/hasp.c
+++ b/src/main/hook/patch/hasp.c
@@ -74,6 +74,8 @@ void patch_hasp_init(const uint8_t *key_data, size_t len)
   util_patch_function((uintptr_t) func_api_decrypt, sec_hasp_api_decrypt);
   util_patch_function((uintptr_t) func_api_getid, sec_hasp_api_getid);
 
+  util_patch_function(0x80dbd50, sec_hasp_api_get_sessioninfo);
+
   sec_hasp_init(key_data, len);
 
   log_info("Initialized");

--- a/src/main/hook/patch/hasp.c
+++ b/src/main/hook/patch/hasp.c
@@ -1,5 +1,7 @@
 #define LOG_MODULE "patch-hasp"
 
+#include <inttypes.h>
+
 #include "sec/hasp/old/hasp.h"
 
 #include "util/log.h"
@@ -26,7 +28,10 @@ static const uint8_t patch_hasp_login_sig[] = {
 static const uint8_t patch_hasp_id_sig[] = {
     0x53, 0x83, 0xEC, 0x48, 0xC7, 0x44, 0x24, 0x10};
 
-void patch_hasp_init(const uint8_t *key_data, size_t len)
+void patch_hasp_init(
+    const uint8_t *key_data,
+    size_t len,
+    uintptr_t addr_get_sessioninfo)
 {
   void *func_api_login;
   void *func_api_logout;
@@ -74,7 +79,10 @@ void patch_hasp_init(const uint8_t *key_data, size_t len)
   util_patch_function((uintptr_t) func_api_decrypt, sec_hasp_api_decrypt);
   util_patch_function((uintptr_t) func_api_getid, sec_hasp_api_getid);
 
-  util_patch_function(0x80dbd50, sec_hasp_api_get_sessioninfo);
+  if (addr_get_sessioninfo) {
+    log_debug("ApiGetSessionInfo at 0x%" PRIxPTR, addr_get_sessioninfo);
+    util_patch_function(addr_get_sessioninfo, sec_hasp_api_get_sessioninfo);
+  }
 
   sec_hasp_init(key_data, len);
 

--- a/src/main/hook/patch/hasp.h
+++ b/src/main/hook/patch/hasp.h
@@ -4,12 +4,19 @@
 #ifndef PATCH_HASP_H
 #define PATCH_HASP_H
 
+#include <stddef.h>
+#include <stdint.h>
+
 /**
  * Initialize the patch module
  *
  * @param key_data Pointer to loaded key data (key table)
  * @param len Length of the buffer
+ * @param addr_get_sessioninfo Address of hasp_get_sessioninfo function (0 if not used)
  */
-void patch_hasp_init(const uint8_t *key_data, size_t len);
+void patch_hasp_init(
+    const uint8_t *key_data,
+    size_t len,
+    uintptr_t addr_get_sessioninfo);
 
 #endif

--- a/src/main/hook/patch/piuio-exit.c
+++ b/src/main/hook/patch/piuio-exit.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 
 #include "capnhook/hook/usbhook.h"
 
@@ -65,7 +66,7 @@ static enum cnh_result patch_piuio_exit_usbhook(struct cnh_usbhook_irp *irp)
           if (((~irp->ctrl_buffer.bytes[1]) & (1 << 1)) &&
               ((~irp->ctrl_buffer.bytes[1]) & (1 << 6))) {
             log_info("Exit on service + test enabled and hit, bye");
-            exit(0);
+            _exit(0);
           }
         }
       }

--- a/src/main/hook/pri/main.c
+++ b/src/main/hook/pri/main.c
@@ -197,7 +197,8 @@ static void prihook_patch_dongle_init()
   patch_hasp_init(
       (const uint8_t *) _binary_prihook_hasp_key_start,
       ((uintptr_t) &_binary_prihook_hasp_key_end -
-       (uintptr_t) &_binary_prihook_hasp_key_start));
+       (uintptr_t) &_binary_prihook_hasp_key_start),
+      0);
 }
 
 static void prihook_patch_hdd_check_init()

--- a/src/main/sec/hasp/old/hasp.c
+++ b/src/main/sec/hasp/old/hasp.c
@@ -95,3 +95,14 @@ int sec_hasp_api_decrypt(int handle, void *buffer, size_t length)
 
   return 0;
 }
+
+int sec_hasp_api_get_sessioninfo(int handle, const char *format, const char **info)
+{
+  static const char dummy_info[] = "p ";
+
+  if (info) {
+    *info = dummy_info;
+  }
+
+  return 0;
+}

--- a/src/main/sec/hasp/old/hasp.h
+++ b/src/main/sec/hasp/old/hasp.h
@@ -32,4 +32,6 @@ unsigned int sec_hasp_api_getid(void);
 
 int sec_hasp_api_decrypt(int handle, void *buffer, size_t length);
 
+int sec_hasp_api_get_sessioninfo(int handle, const char *format, const char **info);
+
 #endif


### PR DESCRIPTION
I was trying to do something else and found out that USB profiles on Fiesta 2 don't work, when you introduce empty drive or a drive with valid fiesta2 profile on it, the game will just freeze on the title screen and spam the log with HASP login/out attempts roughly 10 times per frame.

I was sent a patched hook.so that has been manually edited, reverse engineered the short function and implemented it here in this pull request.

Needs to be tested on arcade still.

Edit:
Fiesta2 works, but Prime1 you can't get to the service menu. Needs to be addressed.

Edit 2:
Now correctly compiles for Fiesta2 only.